### PR TITLE
Python 2.7 Compatibility and Additional Tweaks.

### DIFF
--- a/Source/PythonConsole/Private/SPythonLog.cpp
+++ b/Source/PythonConsole/Private/SPythonLog.cpp
@@ -10,6 +10,21 @@
 //#include "UnrealEnginePython.h"
 #define LOCTEXT_NAMESPACE "PythonConsole"
 
+#if PY_MAJOR_VERSION <= 3
+namespace
+{
+	char* PyUnicode_AsUTF8(PyObject* pyStr)
+	{
+		if (PyUnicode_Check(pyStr)) {
+			pyStr = PyUnicode_AsUTF8String(pyStr);
+			if (pyStr == NULL) {
+				return NULL;
+			}
+		}
+		return PyString_AsString(pyStr);
+	}
+}
+#endif
 
 /** Custom console editable text box whose only purpose is to prevent some keys from being typed */
 class SPythonConsoleEditableTextBox : public SEditableTextBox

--- a/Source/PythonConsole/PythonConsole.Build.cs
+++ b/Source/PythonConsole/PythonConsole.Build.cs
@@ -6,7 +6,7 @@ using System.IO;
 public class PythonConsole : ModuleRules
 {
 
-    private const string pythonHome = "python35";
+    private const string pythonHome = "python27";
 
     protected string PythonHome
     {
@@ -43,7 +43,7 @@ public class PythonConsole : ModuleRules
         if ((Target.Platform == UnrealTargetPlatform.Win64) || (Target.Platform == UnrealTargetPlatform.Win32))
         {
             PublicIncludePaths.Add(PythonHome);
-            PublicAdditionalLibraries.Add(Path.Combine(PythonHome, "libs", "python35.lib"));
+            PublicAdditionalLibraries.Add(Path.Combine(PythonHome, "libs", pythonHome + ".lib"));
         }
         else if (Target.Platform == UnrealTargetPlatform.Mac)
         {

--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -32,20 +32,24 @@ DEFINE_LOG_CATEGORY(LogPython);
 
 PyDoc_STRVAR(unreal_engine_py_doc, "Unreal Engine Python module.");
 
+const char* PY_MOD_NAME = "_unreal_engine";
+
+#if PY_MAJOR_VERSION >= 3
 static PyModuleDef unreal_engine_module = {
 	PyModuleDef_HEAD_INIT,
-	"unreal_engine",
+	PY_MOD_NAME,
 	unreal_engine_py_doc,
 	-1,
 	NULL,
 };
 
-UPythonGCManager *PythonGCManager;
-
 static PyObject *init_unreal_engine(void) {
 	return PyModule_Create(&unreal_engine_module);
 }
 
+#endif
+
+UPythonGCManager *PythonGCManager;
 
 static PyMethodDef unreal_engine_methods[] = {
 	{ "log", py_unreal_engine_log, METH_VARARGS, "" },
@@ -444,8 +448,13 @@ static PyTypeObject ue_PyUObjectType = {
 
 
 void unreal_engine_init_py_module() {
-	PyImport_AppendInittab("unreal_engine", init_unreal_engine);
-	PyObject *new_unreal_engine_module = PyImport_AddModule("unreal_engine");
+	PyObject *new_unreal_engine_module;
+#if PY_MAJOR_VERSION >= 3
+	PyImport_AppendInittab(PY_MOD_NAME, init_unreal_engine);
+	new_unreal_engine_module = PyImport_AddModule(PY_MOD_NAME);
+#else
+	new_unreal_engine_module = Py_InitModule3(PY_MOD_NAME, NULL, unreal_engine_py_doc);
+#endif
 
 	PyObject *unreal_engine_dict = PyModule_GetDict(new_unreal_engine_module);
 
@@ -455,7 +464,6 @@ void unreal_engine_init_py_module() {
 		PyDict_SetItemString(unreal_engine_dict, unreal_engine_function->ml_name, func);
 		Py_DECREF(func);
 	}
-
 
 	ue_PyUObjectType.tp_new = PyType_GenericNew;
 	if (PyType_Ready(&ue_PyUObjectType) < 0)
@@ -574,6 +582,8 @@ ue_PyUObject *ue_get_python_wrapper(UObject *ue_obj) {
 	return ue_py_object->py_object;
 }
 
+// This version of log_error doesn't correctly log the error to the console when using python 2.
+#if PY_MAJOR_VERSION >= 3
 void unreal_engine_py_log_error() {
 	PyObject *type = NULL;
 	PyObject *value = NULL;
@@ -636,6 +646,46 @@ void unreal_engine_py_log_error() {
 
 	PyErr_Clear();
 }
+#else
+void unreal_engine_py_log_error() {
+	PyObject *exception, *v, *traceback;
+	PyErr_Fetch(&exception, &v, &traceback);
+	PyErr_NormalizeException(&exception, &v, &traceback);
+
+	/*
+	import traceback
+	lst = traceback.format_exception(exception, v, traceback)
+	*/
+	PyObject* tbstr = PyString_FromString("traceback");
+	PyObject* tbmod = PyImport_Import(tbstr);
+	if (!tbmod) {
+		UE_LOG(LogPython, Error, TEXT("traceback module missing."));
+		return;
+	}
+	PyObject* tbdict = PyModule_GetDict(tbmod);
+	PyObject* formatFunc = PyDict_GetItemString(tbdict, "format_exception");
+	if (!formatFunc){
+		UE_LOG(LogPython, Error, TEXT("Can't find traceback.format_exception"));
+		return;
+	}
+	if (!traceback) {
+		traceback = Py_None;
+		Py_INCREF(Py_None);
+	}
+	PyObject* args = Py_BuildValue("(OOO)", exception, v, traceback);
+	PyObject* lst = PyObject_CallObject(formatFunc, args);
+
+	for (int i = 0; i<PyList_GET_SIZE(lst); i++) {
+		// Strip off the newline so the error messages don't have gaps.
+		char *str = PyString_AsString(PyList_GetItem(lst, i));
+		str[strlen(str) - 1] = 0;
+		UE_LOG(LogPython, Error, TEXT("%s"), UTF8_TO_TCHAR(str));
+	}
+
+	Py_DECREF(args);
+	Py_DECREF(lst);
+}
+#endif
 
 // retrieve a UWorld from a generic UObject (if possible)
 UWorld *ue_get_uworld(ue_PyUObject *py_obj) {

--- a/Source/UnrealEnginePython/Private/UnrealEnginePythonPrivatePCH.h
+++ b/Source/UnrealEnginePython/Private/UnrealEnginePythonPrivatePCH.h
@@ -1,5 +1,6 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
+#pragma once
 //#define UEPY_MEMORY_DEBUG	1
 //#define UEPY_THREADING 1
 
@@ -18,6 +19,22 @@
 #include <python3.5m/Python.h>
 #else
 #include <include/Python.h>
+#endif
+
+#if PY_MAJOR_VERSION <= 3
+namespace
+{
+	char* PyUnicode_AsUTF8(PyObject* pyStr)
+	{
+		if (PyUnicode_Check(pyStr)) {
+			pyStr = PyUnicode_AsUTF8String(pyStr);
+			if (pyStr == NULL) {
+				return NULL;
+			}
+		}
+		return PyString_AsString(pyStr);
+	}
+}
 #endif
 
 #include "UEPyModule.h"

--- a/Source/UnrealEnginePython/UnrealEnginePython.Build.cs
+++ b/Source/UnrealEnginePython/UnrealEnginePython.Build.cs
@@ -6,13 +6,13 @@ using System.IO;
 public class UnrealEnginePython : ModuleRules
 {
 
-    private const string pythonHome = "python35";
+    private const string PythonVersion = "python27";
 
     protected string PythonHome
     {
         get
         {
-            return Path.GetFullPath(Path.Combine(ModuleDirectory, "..", "..", pythonHome));
+            return Path.GetFullPath(Path.Combine(ModuleDirectory, "..", "..", PythonVersion));
         }
     }
 
@@ -79,7 +79,7 @@ public class UnrealEnginePython : ModuleRules
         if ((Target.Platform == UnrealTargetPlatform.Win64) || (Target.Platform == UnrealTargetPlatform.Win32))
         {
             PublicIncludePaths.Add(PythonHome);
-            PublicAdditionalLibraries.Add(Path.Combine(PythonHome, "libs", "python35.lib"));
+            PublicAdditionalLibraries.Add(Path.Combine(PythonHome, "libs", PythonVersion + ".lib"));
         }
         else if (Target.Platform == UnrealTargetPlatform.Mac)
         {

--- a/unreal_engine.py
+++ b/unreal_engine.py
@@ -1,0 +1,30 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import sys
+
+# python 2 and 3 compatibility. makes all classes new-style in python2 and has
+# no effect in python 3.
+__metaclass__ = type
+
+# Since this is meant as a wrapper around _unreal_engine import everthing
+# into locals.
+from _unreal_engine import *
+
+class UnrealEngineLogger:
+
+    def __init__(self, logger):
+        self.logger = logger
+
+    def write(self, buf):
+        for line in buf.split("\n"):
+            self.logger(buf)
+
+    def flush(self):
+        return
+
+sys.stdout = UnrealEngineLogger(log)
+sys.stderr = UnrealEngineLogger(log_error)
+
+# The following should log to the Unreal Console due to our override of
+# sys.stdout.
+print("Unreal Python Module Startup Complete")


### PR DESCRIPTION
@rdeioris here is where I'm at with the changes for python2.7 as mentioned in #4. Included are a few other tweaks that you may or may not want to merge. I pushed it all up as is so you could take a look and I could get your opinion. 

The first big change beyond python2.7 support is I've renamed the built-in unreal_engine module to _unreal_engine and included an unreal_engine.py module which would wrap around _unreal_engine allowing us to add in additional code in python rather than C++ (auto python class generation, etc.). This follows the model I've seen elsewhere where compiled modules start with an underscore and the modules intended for import are the same name minus the underscore. This module should be located in {UnrealProject}/Content/Scripts and will be imported at the plugin startup. Due to it setting up the Unreal logging I removed the exception handling code that was previously in PythonConsole as it was redundant. This is also where we can setup the Qt event loop or implement a startup hook which will execute additional startup scripts that a user or studio can write their own additional startup logic.

The other big change I made is contained in StartupModule(). I did not have a lot of success getting a zip to work beyond the base Lib scripts. Lib\site-packages was not consistently loading all modules due to .pth files not being respected in a zip and the DLLs were not importing correctly when in a zip even with the {zip_path}\DLLs path being present in sys.path. I ended up delaying site.py from executing by using Py_NoSiteFlag, calling Py_SetProgramHome and then running a SimpleString command which adds to sys.path after Initialize has been called. After unreal_engine.py is imported I finally run site.py which will perform additional startup logic such as importing a sitecustomize file, processing the .pth files, etc. Now the intention is that the user will have all of the stock python files (DLLs, Lib and any additional site-packages) in {UnrealProject}\Content\Scripts\python## where ## is the major and minor python version number. It is possible that we can still zip only Lib and then provide DLLs and site-packages as regular folders. I'm not sure how important it is to keep Lib zipped up.

I also started to add in the basic thread support that I had mentioned in Issue #10 in the PythonConsole module. 

I have not tested these changes with python3.5 yet. I haven't had a chance to get an environment all setup for that. I wanted to get these changes up for you to look at first.

Finally thank you for getting this project started! I had started playing with something on the side but this is much more fleshed out. I'm looking forward to being able to reuse python code and more tightly integrate with Unreal Editor.