### PR TITLE
Adds A Basic Python Commandlet.

### DIFF
--- a/Source/UnrealEnginePython/Private/UnrealEnginePython.cpp
+++ b/Source/UnrealEnginePython/Private/UnrealEnginePython.cpp
@@ -117,7 +117,11 @@ void FUnrealEnginePythonModule::RunString(char *str) {
 
 void FUnrealEnginePythonModule::RunFile(char *filename) {
 	FScopePythonGIL gil;
-	char *full_path = TCHAR_TO_UTF8(*FPaths::Combine(*FPaths::GameContentDir(), UTF8_TO_TCHAR("Scripts"), *FString("/"), UTF8_TO_TCHAR(filename)));
+	char *full_path = filename;
+	if (!FPaths::FileExists(filename))
+	{
+		full_path = TCHAR_TO_UTF8(*FPaths::Combine(*FPaths::GameContentDir(), UTF8_TO_TCHAR("Scripts"), *FString("/"), UTF8_TO_TCHAR(filename)));
+	}
 	FILE *fd = nullptr;
 	
 #if PLATFORM_WINDOWS

--- a/Source/UnrealEnginePython/Public/PyCommandlet.cpp
+++ b/Source/UnrealEnginePython/Public/PyCommandlet.cpp
@@ -1,0 +1,86 @@
+#include "UnrealEnginePythonPrivatePCH.h"
+#include "PyCommandlet.h"
+
+#include "Regex.h"
+
+UPyCommandlet::UPyCommandlet(const FObjectInitializer& ObjectInitializer) 
+	: Super(ObjectInitializer)
+{
+	LogToConsole = 1;
+}
+
+int32 UPyCommandlet::Main(const FString& CommandLine)
+{
+	TArray<FString> Tokens, Switches;
+	TMap<FString, FString> Params;
+	ParseCommandLine(*CommandLine, Tokens, Switches, Params);
+
+	FString Filepath = Tokens[0];
+	if (!FPaths::FileExists(*Filepath))
+	{
+		UE_LOG(LogPython, Error, TEXT("Python file could not be found: %s"), *Filepath);
+		return -1;
+	}
+
+	FString RegexString = FString::Printf(TEXT("(?<=%s).*"), *(Filepath.Replace(TEXT("\\"), TEXT("\\\\"))));
+	const FRegexPattern myPattern(RegexString);
+	FRegexMatcher myMatcher(myPattern, *CommandLine);
+	myMatcher.FindNext();
+	FString PyCommandLine = myMatcher.GetCaptureGroup(0).Trim().TrimTrailing();
+	
+	TArray<FString> PyArgv = {FString()};
+	bool escaped = false;
+	for (int i = 0; i < PyCommandLine.Len(); i++)
+	{
+		if(PyCommandLine[i] == ' ')
+		{
+			PyArgv.Add(FString());
+			continue;
+		}
+		else if(PyCommandLine[i] == '\"' && !escaped)
+		{
+			i++;
+			while(i < PyCommandLine.Len() && !(PyCommandLine[i] == '"'))
+			{
+				PyArgv[PyArgv.Num() - 1].AppendChar(PyCommandLine[i]);
+				i++;
+				if (i == PyCommandLine.Len())
+				{
+					PyArgv[PyArgv.Num() - 1].InsertAt(0, "\"");
+				}
+			}
+		}
+		else
+		{
+			if (PyCommandLine[i] == '\\')
+				escaped = true;
+			else
+				escaped = false;
+			PyArgv[PyArgv.Num() - 1].AppendChar(PyCommandLine[i]);
+		}
+	}
+	PyArgv.Insert(Filepath, 0);
+
+#if PY_MAJOR_VERSION >= 3
+	wchar_t **argv = (**wchar_t)malloc(PyArgv.Num() * sizeof(void*));
+#else
+	char **argv = (char **)malloc(PyArgv.Num() * sizeof(void*));
+#endif
+
+	for (int i=0; i<PyArgv.Num(); i++)
+	{
+#if PY_MAJOR_VERSION >= 3
+		argv[i] = (wchar_t*)malloc(PyArgv[i].Len()+1);
+		wcscpy_s(argv[i], PyArgv[i].Len()+1, *PyArgv[i].ReplaceEscapedCharWithChar());
+#else
+		argv[i] = (char*)malloc(PyArgv[i].Len() + 1);
+		strcpy_s(argv[i], PyArgv[i].Len()+1, TCHAR_TO_UTF8(*PyArgv[i].ReplaceEscapedCharWithChar()));
+#endif
+	}
+
+	PySys_SetArgv(PyArgv.Num(), argv);
+
+	FUnrealEnginePythonModule &PythonModule = FModuleManager::GetModuleChecked<FUnrealEnginePythonModule>("UnrealEnginePython");
+	PythonModule.RunFile(TCHAR_TO_UTF8(*Filepath));
+	return 0;
+}

--- a/Source/UnrealEnginePython/Public/PyCommandlet.h
+++ b/Source/UnrealEnginePython/Public/PyCommandlet.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "UnrealEd.h"
+#include "Core.h"
+#include "Commandlets/Commandlet.h"
+#include "PyCommandlet.generated.h"
+
+UCLASS()
+class UPyCommandlet : public UCommandlet
+{
+	GENERATED_UCLASS_BODY()
+	virtual int32 Main(const FString& Params) override;
+};


### PR DESCRIPTION
This pull request adds a basic python commandlet which can be invoked to execute a python script using a headless Unreal Engine instance.

It can be invoked by:

    UE4Editor.exe -run=UnrealEnginePython.PyCommandlet <PATH_TO_PYTHON_SCRIPT> <PYTHON_SCRIPT_CMD_ARGS>

Example:

    UE4Editor.exe -run=UnrealEnginePython.PyCommandlet C:\test_script.py --test_arg_a 1 2 3 4 -test_arg_b "Spaces In Args Will Work" -test_arg_c EscapedQuotes\"AlsoWork -test_arg_d "OtherEscapedCharacters\nAlsoWork"

The python script path is the only token expected and it is expected to come after any Unreal arguments. Any arguments desired to be available to python must come after the python script path. Unreal switches and parameters should work fine as long as they come before the python path.

The arguments format doesn't matter to the commandlet, they will be passed along to python and are available as a list in sys.argv along with the script path.

FUnrealEnginePythonModule::RunFile has been modified to only prepend the project scripts directory to the filename if the filename doesn't already exist. This allows passing in files that exist in other directories.