### PR TITLE
Refactors get_asset_import_data to return list of dicts.

### DIFF
--- a/Source/UnrealEnginePython/Private/UEPyAssetUserData.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyAssetUserData.cpp
@@ -1,6 +1,5 @@
 #include "UnrealEnginePythonPrivatePCH.h"
 
-
 PyObject *py_ue_asset_import_data(ue_PyUObject * self, PyObject * args) {
 
 	ue_py_check(self);
@@ -12,11 +11,15 @@ PyObject *py_ue_asset_import_data(ue_PyUObject * self, PyObject * args) {
 		
 	}
 	UAssetImportData *import_data = (UAssetImportData *)u_property->GetPropertyValue_InContainer(self->ue_object);
-	FString absolute_filepath = import_data->ResolveImportFilename(import_data->GetFirstFilename(), NULL);
-
-	PyObject *ret = PyDict_New();
-	PyDict_SetItemString(ret, "absolute_filepath", PyUnicode_FromString(TCHAR_TO_UTF8(*absolute_filepath)));
-	PyDict_SetItemString(ret, "relative_filepath", PyUnicode_FromString(TCHAR_TO_UTF8(*import_data->GetFirstFilename())));
-
+	FAssetImportInfo *import_info = &import_data->SourceData;
+	PyObject *ret = PyList_New(import_info->SourceFiles.Num());
+	for (int i=0; i < import_info->SourceFiles.Num(); i++) {
+		PyObject *py_source_file = PyDict_New();
+		PyDict_SetItemString(py_source_file, "absolute_filepath", PyUnicode_FromString(TCHAR_TO_UTF8(*import_data->ResolveImportFilename(import_info->SourceFiles[i].RelativeFilename, NULL))));
+		PyDict_SetItemString(py_source_file, "relative_filepath", PyUnicode_FromString(TCHAR_TO_UTF8(*import_info->SourceFiles[i].RelativeFilename)));
+		PyDict_SetItemString(py_source_file, "timestamp", PyLong_FromLong(import_info->SourceFiles[i].Timestamp.ToUnixTimestamp()));
+		PyDict_SetItemString(py_source_file, "filehash", PyUnicode_FromString(TCHAR_TO_UTF8(*LexicalConversion::ToString(import_info->SourceFiles[i].FileHash))));
+		PyList_SetItem(ret, i, py_source_file);
+	}
 	return ret;
 }


### PR DESCRIPTION
Previously the data returned was not entirely accurate (relative_file was not actually relative) plus
this change is more future proof in cases where assets were imported from more than one file.

This change also adds extra metadata: timestamp and filehash.