### PR TITLE
Fixes pygilstate compiler errors for Python < 3.

### DIFF
--- a/Source/UnrealEnginePython/Private/UnrealEnginePython.cpp
+++ b/Source/UnrealEnginePython/Private/UnrealEnginePython.cpp
@@ -20,6 +20,11 @@ char *PyUnicode_AsUTF8(PyObject *py_str) {
 	}
 	return PyString_AsString(py_str);
 }
+
+int PyGILState_Check() {
+	PyThreadState * tstate = _PyThreadState_Current;
+	return tstate && (tstate == PyGILState_GetThisThreadState());
+}
 #endif
 
 bool PyUnicodeOrString_Check(PyObject *py_obj) {

--- a/Source/UnrealEnginePython/Private/UnrealEnginePythonPrivatePCH.h
+++ b/Source/UnrealEnginePython/Private/UnrealEnginePythonPrivatePCH.h
@@ -50,9 +50,6 @@
 
 #if PY_MAJOR_VERSION < 3
 char *PyUnicode_AsUTF8(PyObject *py_str);
-int PyGILState_Check() {
-	PyThreadState * tstate = _PyThreadState_Current;
-	return tstate && (tstate == PyGILState_GetThisThreadState());
-}
+int PyGILState_Check();
 #endif
 bool PyUnicodeOrString_Check(PyObject *py_obj);


### PR DESCRIPTION
Without this we get errors about PyGilState_Check already having a body.