### PR TITLE
Add flag to return FAssetData

### DIFF
--- a/Source/UnrealEnginePython/Private/UEPyEditor.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyEditor.cpp
@@ -267,8 +267,9 @@ PyObject *py_unreal_engine_get_assets(PyObject * self, PyObject * args) {
 PyObject *py_unreal_engine_get_assets_by_filter(PyObject * self, PyObject * args) {
 
 	PyObject *pyfilter;
+	PyObject *py_return_asset_data;
 
-	if (!PyArg_ParseTuple(args, "O:get_assets_by_filter", &pyfilter)) {
+	if (!PyArg_ParseTuple(args, "O|O:get_assets_by_filter", &pyfilter, &py_return_asset_data)) {
 		return NULL;
 	}
 
@@ -285,13 +286,24 @@ PyObject *py_unreal_engine_get_assets_by_filter(PyObject * self, PyObject * args
 	AssetRegistryModule.Get().SearchAllAssets(true);
 	AssetRegistryModule.Get().GetAssets(filter->filter, assets);
 
+	bool return_asset_data = false;
+	if (py_return_asset_data && PyObject_IsTrue(py_return_asset_data))
+		return_asset_data = true;
 	PyObject *assets_list = PyList_New(0);
 	for (FAssetData asset : assets) {
 		if (!asset.IsValid())
 			continue;
-		ue_PyUObject *ret = ue_get_python_wrapper(asset.GetAsset());
+		PyObject *ret = nullptr;
+		if (return_asset_data) {
+			// Copy isn't working due to an issue with the TSharedMapView TagsAndValues memory 
+			FAssetData *asset_data = new FAssetData(asset.PackageName, asset.PackagePath, asset.GroupNames, asset.AssetName, asset.AssetClass, asset.TagsAndValues.GetMap(), asset.ChunkIDs, asset.PackageFlags);
+			ret = py_ue_new_fassetdata(asset_data);
+		}
+		else {
+			ret = (PyObject *)ue_get_python_wrapper(asset.GetAsset());
+		}
 		if (ret) {
-			PyList_Append(assets_list, (PyObject *)ret);
+			PyList_Append(assets_list, ret);
 		}
 	}
 

--- a/Source/UnrealEnginePython/Private/UEPyEngine.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyEngine.cpp
@@ -133,6 +133,14 @@ PyObject *py_unreal_engine_get_content_dir(PyObject * self, PyObject * args) {
 	return PyUnicode_FromString(TCHAR_TO_UTF8(*FPaths::GameContentDir()));
 }
 
+PyObject *py_unreal_engine_convert_relative_path_to_full(PyObject * self, PyObject * args) {
+	char *path;
+	if (!PyArg_ParseTuple(args, "s:convert_relative_path_to_full", &path)) {
+		return NULL;
+	}
+	return PyUnicode_FromString(TCHAR_TO_UTF8(*FPaths::ConvertRelativePathToFull(UTF8_TO_TCHAR(path))));
+}
+
 PyObject *py_unreal_engine_find_class(PyObject * self, PyObject * args) {
 	char *name;
 	if (!PyArg_ParseTuple(args, "s:find_class", &name)) {

--- a/Source/UnrealEnginePython/Private/UEPyFAssetData.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyFAssetData.cpp
@@ -1,0 +1,125 @@
+#include "UnrealEnginePythonPrivatePCH.h"
+
+#if WITH_EDITOR
+
+static PyObject *py_ue_fassetdata_get_asset(ue_PyFAssetData *self, PyObject * args) {
+	return (PyObject *)ue_get_python_wrapper(self->asset_data->GetAsset());
+}
+
+static PyObject *py_ue_fassetdata_is_asset_loaded(ue_PyFAssetData *self, PyObject * args) {
+	if (self->asset_data->IsAssetLoaded())
+		Py_RETURN_TRUE;
+	Py_RETURN_FALSE;
+}
+
+static PyMethodDef ue_PyFAssetData_methods[] = {
+	{ "get_asset", (PyCFunction)py_ue_fassetdata_get_asset, METH_VARARGS, "" },
+	{ "is_asset_loaded", (PyCFunction)py_ue_fassetdata_is_asset_loaded, METH_VARARGS, "" },
+	{ NULL }  /* Sentinel */
+};
+
+static PyMemberDef ue_PyFAssetData_members[] = {
+	{ (char *)"asset_class", T_OBJECT, offsetof(ue_PyFAssetData, asset_class), READONLY, (char *)"asset_class" },
+	{ (char *)"asset_name", T_OBJECT, offsetof(ue_PyFAssetData, asset_name), READONLY, (char *)"asset_name" },
+	{ (char *)"group_names", T_OBJECT, offsetof(ue_PyFAssetData, group_names), READONLY, (char *)"group_names" },
+	{ (char *)"object_path", T_OBJECT, offsetof(ue_PyFAssetData, object_path), READONLY, (char *)"object_path" },
+	{ (char *)"package_flags", T_OBJECT, offsetof(ue_PyFAssetData, package_flags), READONLY, (char *)"package_flags" },
+	{ (char *)"package_name", T_OBJECT, offsetof(ue_PyFAssetData, package_name), READONLY, (char *)"package_name" },
+	{ (char *)"package_path", T_OBJECT, offsetof(ue_PyFAssetData, package_path), READONLY, (char *)"package_path" },
+	{ (char *)"tags_and_values", T_OBJECT, offsetof(ue_PyFAssetData, tags_and_values), READONLY, (char *)"tags_and_values" },
+	{ NULL }  /* Sentinel */
+};
+
+static int ue_py_fassetdata_init(ue_PyFAssetData *self, PyObject *args, PyObject *kwargs) {
+	return 0;
+}
+
+static void ue_py_fassetdata_dealloc(ue_PyFAssetData *self) {
+	Py_XDECREF(self->asset_class);
+	Py_XDECREF(self->asset_name);
+	Py_XDECREF(self->group_names);
+	Py_XDECREF(self->object_path);
+	Py_XDECREF(self->package_flags);
+	Py_XDECREF(self->package_name);
+	Py_XDECREF(self->package_path);
+	Py_XDECREF(self->tags_and_values);
+
+#if PY_MAJOR_VERSION < 3
+	self->ob_type->tp_free((PyObject*)self);
+#else
+	Py_TYPE(self)->tp_free((PyObject*)self);
+#endif
+}
+
+static PyTypeObject ue_PyFAssetDataType = {
+	PyVarObject_HEAD_INIT(NULL, 0)
+	"unreal_engine.FAssetData", /* tp_name */
+	sizeof(ue_PyFAssetData),    /* tp_basicsize */
+	0,                         /* tp_itemsize */
+	(destructor)ue_py_fassetdata_dealloc,   /* tp_dealloc */
+	0,                         /* tp_print */
+	0,                         /* tp_getattr */
+	0,                         /* tp_setattr */
+	0,                         /* tp_reserved */
+	0,                         /* tp_repr */
+	0,                         /* tp_as_number */
+	0,                         /* tp_as_sequence */
+	0,                         /* tp_as_mapping */
+	0,                         /* tp_hash  */
+	0,                         /* tp_call */
+	0,                         /* tp_str */
+	0,                         /* tp_getattro */
+	0,                         /* tp_setattro */
+	0,                         /* tp_as_buffer */
+	Py_TPFLAGS_DEFAULT,        /* tp_flags */
+	"Unreal Engine FAssetData", /* tp_doc */
+	0,                         /* tp_traverse */
+	0,                         /* tp_clear */
+	0,                         /* tp_richcompare */
+	0,                         /* tp_weaklistoffset */
+	0,                         /* tp_iter */
+	0,                         /* tp_iternext */
+	ue_PyFAssetData_methods,    /* tp_methods */
+	ue_PyFAssetData_members,   /* tp_members */
+	0,                         /* tp_getset */
+};
+
+void ue_python_init_fassetdata(PyObject *ue_module) {
+	ue_PyFAssetDataType.tp_new = PyType_GenericNew;;
+	ue_PyFAssetDataType.tp_init = (initproc)ue_py_fassetdata_init;
+	if (PyType_Ready(&ue_PyFAssetDataType) < 0)
+		return;
+
+	Py_INCREF(&ue_PyFAssetDataType);
+	PyModule_AddObject(ue_module, "FAssetData", (PyObject *)&ue_PyFAssetDataType);
+}
+
+PyObject *py_ue_new_fassetdata(FAssetData *asset_data) {
+	ue_PyFAssetData *ret = (ue_PyFAssetData *)PyObject_New(ue_PyFAssetData, &ue_PyFAssetDataType);
+		
+	ret->asset_class = PyString_FromString(TCHAR_TO_UTF8(*asset_data->AssetClass.ToString()));
+	ret->asset_name = PyString_FromString(TCHAR_TO_UTF8(*asset_data->AssetName.ToString()));
+	ret->group_names = PyString_FromString(TCHAR_TO_UTF8(*asset_data->GroupNames.ToString()));
+	ret->object_path = PyString_FromString(TCHAR_TO_UTF8(*asset_data->ObjectPath.ToString()));
+	ret->package_flags = PyInt_FromLong(asset_data->PackageFlags);
+	ret->package_name = PyString_FromString(TCHAR_TO_UTF8(*asset_data->PackageName.ToString()));
+	ret->package_path = PyString_FromString(TCHAR_TO_UTF8(*asset_data->PackagePath.ToString()));
+	ret->tags_and_values = PyDict_New();
+	for (auto It = asset_data->TagsAndValues.CreateConstIterator(); It; ++It)
+	{
+		PyDict_SetItem(ret->tags_and_values, 
+			           PyString_FromString(TCHAR_TO_UTF8(*It->Key.ToString())), 
+					   PyString_FromString(TCHAR_TO_UTF8(*It->Value)));
+	}
+
+	ret->asset_data = asset_data;
+	return (PyObject *)ret;
+}
+
+ue_PyFAssetData *py_ue_is_fassetdata(PyObject *obj) {
+	if (!PyObject_IsInstance(obj, (PyObject *)&ue_PyFAssetDataType))
+		return nullptr;
+	return (ue_PyFAssetData *)obj;
+}
+
+#endif

--- a/Source/UnrealEnginePython/Private/UEPyFAssetData.h
+++ b/Source/UnrealEnginePython/Private/UEPyFAssetData.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "UnrealEnginePython.h"
+
+#if WITH_EDITOR
+
+struct ue_PyFAssetData {
+	PyObject_HEAD
+		/* Type-specific fields go here. */
+		FAssetData *asset_data;
+	PyObject *asset_class;
+	PyObject *asset_name;
+	PyObject *group_names;
+	PyObject *object_path;
+	PyObject *package_flags;
+	PyObject *package_name;
+	PyObject *package_path;
+	PyObject *tags_and_values;
+};
+
+PyObject *py_ue_new_fassetdata(FAssetData *);
+ue_PyFAssetData *py_ue_is_fassetdata(PyObject *);
+
+void ue_python_init_fassetdata(PyObject *);
+
+#endif

--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -127,6 +127,7 @@ static PyMethodDef unreal_engine_methods[] = {
 	{ "get_right_vector", py_unreal_engine_get_right_vector, METH_VARARGS, "" },
 
 	{ "get_content_dir", py_unreal_engine_get_content_dir, METH_VARARGS, "" },
+	{ "convert_relative_path_to_full", py_unreal_engine_convert_relative_path_to_full, METH_VARARGS, "" },
 #if WITH_EDITOR
 	{ "get_editor_world", py_unreal_engine_get_editor_world, METH_VARARGS, "" },
 	{ "editor_get_selected_actors", py_unreal_engine_editor_get_selected_actors, METH_VARARGS, "" },
@@ -965,6 +966,7 @@ void unreal_engine_init_py_module() {
 #if WITH_EDITOR
 	ue_python_init_swidget(new_unreal_engine_module);
 	ue_python_init_farfilter(new_unreal_engine_module);
+	ue_python_init_fassetdata(new_unreal_engine_module);
 #endif
 
 	PyObject *py_sys = PyImport_ImportModule("sys");

--- a/Source/UnrealEnginePython/Private/UnrealEnginePythonPrivatePCH.h
+++ b/Source/UnrealEnginePython/Private/UnrealEnginePythonPrivatePCH.h
@@ -42,6 +42,7 @@
 #include "UEPyEnumsImporter.h"
 
 #if WITH_EDITOR
+#include "UEPyFAssetData.h"
 #include "UEPyFARFilter.h"
 #endif
 


### PR DESCRIPTION
This pull request adds a basic FAssetData wrapper and the ability to get FAssetData objects rather than fully loading assets when calling get_asset_by_filter. 

Before merging I had a few questions. Should we use keyword args for this and add this functionality to the other get_asset* functions? Keyword args haven't been used anywhere else so I did not look into using them here yet.

This is an important addition as the cost of fully loading assets is much higher than simply getting back the FAssetData objects.