### PR TITLE
Fixes issue with passing 2 args to FindPossessableObjectId

### DIFF
--- a/Source/UnrealEnginePython/Private/UEPySequencer.cpp
+++ b/Source/UnrealEnginePython/Private/UEPySequencer.cpp
@@ -201,7 +201,7 @@ PyObject *py_ue_sequencer_add_actor(ue_PyUObject *self, PyObject * args) {
 
 	UObject& u_obj = *actors[0];
 
-	FGuid new_guid = seq->FindPossessableObjectId(u_obj, u_obj.GetWorld());
+	FGuid new_guid = seq->FindPossessableObjectId(u_obj);
 	if (!new_guid.IsValid()) {
 		return PyErr_Format(PyExc_Exception, "unable to find guid");
 	}


### PR DESCRIPTION
Removing the extra argument seems to resolve the issue, might be an engine version mismatch? I'm running 4.14.3