### PR TITLE
Created a 'write_audio_to_buffer' function.

### DIFF
--- a/Source/UnrealEnginePython/Private/UEPyAudio.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyAudio.cpp
@@ -1,5 +1,36 @@
 #include "UnrealEnginePythonPrivatePCH.h"
+#include "Sound/SoundWaveProcedural.h"
 
+PyObject *py_write_audio_to_buffer(ue_PyUObject *self, PyObject * args) {
+	// Writes from a Python buffer object to a USoundWaveProcedural class
+	ue_py_check(self);
+
+	PyObject *sound_procedural;
+	Py_buffer sound_buffer;
+
+	if (!PyArg_ParseTuple(args, "Oy*:write_audio_to_buffer", &sound_procedural, &sound_buffer)) {
+		return NULL;
+	}
+
+	// Convert to USoundWaveProcedural
+	USoundWaveProcedural *sound_wave_procedural = ue_py_check_type<USoundWaveProcedural>(sound_procedural);
+	if (!sound_wave_procedural)
+		return PyErr_Format(PyExc_Exception, "Invalid procedural sound wave object.");
+
+	// Convert the buffer
+	uint8 *buffer = (uint8 *)sound_buffer.buf;
+	if (buffer == nullptr)
+		return PyErr_Format(PyExc_Exception, "Invalid sound buffer.");
+
+	// Add the audio to the Sound Wave's audio buffer
+	sound_wave_procedural->QueueAudio(buffer, sound_buffer.len);
+
+	// Clean up
+	PyBuffer_Release(&sound_buffer);
+
+	Py_INCREF(Py_None);
+	return Py_None;
+}
 
 PyObject *py_ue_play_sound_at_location(ue_PyUObject *self, PyObject * args) {
 

--- a/Source/UnrealEnginePython/Private/UEPyAudio.h
+++ b/Source/UnrealEnginePython/Private/UEPyAudio.h
@@ -4,4 +4,5 @@
 
 #include "UnrealEnginePython.h"
 
+PyObject *py_write_audio_to_buffer(ue_PyUObject *self, PyObject * args);
 PyObject *py_ue_play_sound_at_location(ue_PyUObject *, PyObject *);

--- a/Source/UnrealEnginePython/Private/UEPyAudio.h
+++ b/Source/UnrealEnginePython/Private/UEPyAudio.h
@@ -4,5 +4,5 @@
 
 #include "UnrealEnginePython.h"
 
-PyObject *py_write_audio_to_buffer(ue_PyUObject *self, PyObject * args);
+PyObject *py_queue_procedural_audio(ue_PyUObject *self, PyObject * args);
 PyObject *py_ue_play_sound_at_location(ue_PyUObject *, PyObject *);

--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -524,7 +524,7 @@ static PyMethodDef ue_PyUObject_methods[] = {
 	{ "get_actor_velocity", (PyCFunction)py_ue_get_actor_velocity, METH_VARARGS, "" },
 
 	{ "play_sound_at_location", (PyCFunction)py_ue_play_sound_at_location, METH_VARARGS, "" },
-	{ "write_audio_to_buffer", (PyCFunction)py_write_audio_to_buffer, METH_VARARGS, "" },
+	{ "queue_audio", (PyCFunction)py_queue_procedural_audio, METH_VARARGS, "" },
 
 	{ "world_tick", (PyCFunction)py_ue_world_tick, METH_VARARGS, "" },
 

--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -524,6 +524,7 @@ static PyMethodDef ue_PyUObject_methods[] = {
 	{ "get_actor_velocity", (PyCFunction)py_ue_get_actor_velocity, METH_VARARGS, "" },
 
 	{ "play_sound_at_location", (PyCFunction)py_ue_play_sound_at_location, METH_VARARGS, "" },
+	{ "write_audio_to_buffer", (PyCFunction)py_write_audio_to_buffer, METH_VARARGS, "" },
 
 	{ "world_tick", (PyCFunction)py_ue_world_tick, METH_VARARGS, "" },
 


### PR DESCRIPTION
This function accepts a USoundWaveProcedural and a Python buffer object. The 'QueueAudio' function on the USoundWaveProcedural is called, passing along the binary data within the buffer. This audio can then be played via normal Unreal methods (adding to an AudioComponent, playing sound at a location, etc.).

I'm not entirely sure if this fits in with the rest of the project, given it's a function that applies just for one class (USoundWaveProcedural). Even so, I don't think there is a way to do it entirely within Python, since you'd need to pass in a raw uint8* array to the function.