### PR TITLE
Build issues were missing header references and wrong storage class

### DIFF
--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -860,7 +860,7 @@ static PyObject *ue_PyUObject_call(ue_PyUObject *self, PyObject *args, PyObject 
 	return PyErr_Format(PyExc_Exception, "the specified uobject has no __call__ support");
 }
 
-static PyTypeObject ue_PyUObjectType = {
+PyTypeObject ue_PyUObjectType = {
 	PyVarObject_HEAD_INIT(NULL, 0)
 	"unreal_engine.UObject",             /* tp_name */
 	sizeof(ue_PyUObject), /* tp_basicsize */

--- a/Source/UnrealEnginePython/Private/UEPyTicker.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyTicker.cpp
@@ -1,4 +1,5 @@
 #include "UnrealEnginePythonPrivatePCH.h"
+#include "UEPyTicker.h"
 
 // destructor
 static void ue_pyfdelegatehandle_dealloc(ue_PyFDelegateHandle *self) {

--- a/Source/UnrealEnginePython/Private/UEPyTimer.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyTimer.cpp
@@ -1,4 +1,5 @@
 #include "UnrealEnginePythonPrivatePCH.h"
+#include "UEPyTimer.h"
 
 static PyObject *py_ue_ftimerhandle_clear(ue_PyFTimerHandle *self, PyObject * args) {
 	self->world->GetTimerManager().ClearTimer(self->thandle);

--- a/Source/UnrealEnginePython/Private/UEPyWorld.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyWorld.cpp
@@ -1,4 +1,5 @@
 #include "UnrealEnginePythonPrivatePCH.h"
+extern PyTypeObject ue_PyUObjectType;
 
 PyObject *py_ue_console_exec(ue_PyUObject *self, PyObject * args) {
 

--- a/Source/UnrealEnginePython/Public/PythonBlueprintFunctionLibrary.h
+++ b/Source/UnrealEnginePython/Public/PythonBlueprintFunctionLibrary.h
@@ -6,7 +6,7 @@
 
 
 UCLASS()
-class UPythonBlueprintFunctionLibrary : public UBlueprintFunctionLibrary
+class UNREALENGINEPYTHON_API UPythonBlueprintFunctionLibrary : public UBlueprintFunctionLibrary
 {
 	GENERATED_BODY()
 


### PR DESCRIPTION
Build issues were missing header references and wrong storage class specifiers on certain functions leading to unresolved symbols when building static libraries of plugin