### PR TITLE
Missing include header + ability to find_object scoped to current game world

### DIFF
--- a/Source/UnrealEnginePython/Private/UEPyEngine.h
+++ b/Source/UnrealEnginePython/Private/UEPyEngine.h
@@ -29,8 +29,6 @@ PyObject *py_unreal_engine_string_to_guid(PyObject *, PyObject *);
 
 PyObject *py_unreal_engine_engine_tick(PyObject *, PyObject *);
 
-PyObject *py_unreal_engine_find_object(PyObject *, PyObject *);
-
 PyObject *py_unreal_engine_all_classes(PyObject *, PyObject *);
 
 

--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -552,6 +552,7 @@ static PyMethodDef ue_PyUObject_methods[] = {
 	{ "get_physics_linear_velocity", (PyCFunction)py_ue_get_physics_linear_velocity, METH_VARARGS, "" },
 	{ "set_physics_angular_velocity", (PyCFunction)py_ue_set_physics_angular_velocity, METH_VARARGS, "" },
 	{ "get_physics_angular_velocity", (PyCFunction)py_ue_get_physics_angular_velocity, METH_VARARGS, "" },
+    { "find_object", (PyCFunction)py_ue_find_object, METH_VARARGS, "" },
 	{ "get_world", (PyCFunction)py_ue_get_world, METH_VARARGS, "" },
 	{ "has_world", (PyCFunction)py_ue_has_world, METH_VARARGS, "" },
 

--- a/Source/UnrealEnginePython/Private/UEPyWorld.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyWorld.cpp
@@ -121,6 +121,31 @@ PyObject *py_ue_all_actors(ue_PyUObject * self, PyObject * args) {
 	return ret;
 }
 
+PyObject *py_ue_find_object(ue_PyUObject *self, PyObject * args) {
+
+    ue_py_check(self);
+
+    char *name;
+    if (!PyArg_ParseTuple(args, "s:find_object", &name)) {
+        return NULL;
+    }
+
+    UWorld *world = ue_get_uworld(self);
+    if (!world)
+        return PyErr_Format(PyExc_Exception, "unable to retrieve UWorld from uobject");
+
+    UObject *u_object = FindObject<UObject>(world->GetOutermost(), UTF8_TO_TCHAR(name));
+
+    if (!u_object)
+        return PyErr_Format(PyExc_Exception, "unable to find object %s", name);
+
+    ue_PyUObject *ret = ue_get_python_wrapper(u_object);
+    if (!ret)
+        return PyErr_Format(PyExc_Exception, "uobject is in invalid state");
+    Py_INCREF(ret);
+    return (PyObject *)ret;
+}
+
 PyObject *py_ue_get_world(ue_PyUObject *self, PyObject * args) {
 
 	ue_py_check(self);

--- a/Source/UnrealEnginePython/Private/UEPyWorld.h
+++ b/Source/UnrealEnginePython/Private/UEPyWorld.h
@@ -14,6 +14,7 @@ PyObject *py_ue_world_tick(ue_PyUObject *, PyObject *);
 
 PyObject *py_ue_all_objects(ue_PyUObject *, PyObject *);
 PyObject *py_ue_all_actors(ue_PyUObject *, PyObject *);
+PyObject *py_ue_find_object(ue_PyUObject *, PyObject *);
 PyObject *py_ue_get_world(ue_PyUObject *, PyObject *);
 PyObject *py_ue_has_world(ue_PyUObject *, PyObject *);
 

--- a/Source/UnrealEnginePython/Public/PythonBlueprintFunctionLibrary.h
+++ b/Source/UnrealEnginePython/Public/PythonBlueprintFunctionLibrary.h
@@ -1,8 +1,8 @@
 #pragma once
 
 
+#include "Kismet/BlueprintFunctionLibrary.h"
 #include "PythonBlueprintFunctionLibrary.generated.h"
-
 
 
 UCLASS()


### PR DESCRIPTION
Adding ability to find object based on specific world (useful for PIE).
  Syntax is world.find_object('MyLevelName:PersistentLevel.BP_ActorName')