### PR TITLE
UE4 Editor shutdown crash fix

### DIFF
--- a/Source/PythonEditor/Private/PythonProjectEditor.cpp
+++ b/Source/PythonEditor/Private/PythonProjectEditor.cpp
@@ -102,6 +102,11 @@ public:
 		ViewMenuTooltip = LOCTEXT("ProjectTabMenu_ToolTip", "Shows the project panel");
 	}
 
+	~FProjectViewSummoner()
+	{
+		MyPythonProjectEditor.Reset();
+	}
+
 	virtual TSharedRef<SWidget> CreateTabBody(const FWorkflowTabSpawnInfo& Info) const override
 	{
 		TSharedPtr<FPythonProjectEditor> PythonEditorPtr = StaticCastSharedPtr<FPythonProjectEditor>(HostingApp.Pin());


### PR DESCRIPTION
- Fix for a crash during UE4 editor shutdown when python editor was opened before