### PR TITLE
Add PyCalllable_Check_Extended macro to guard against "callable" uscr…

### DIFF
--- a/Source/UnrealEnginePython/Private/Slate/UEPyFMenuBuilder.cpp
+++ b/Source/UnrealEnginePython/Private/Slate/UEPyFMenuBuilder.cpp
@@ -46,7 +46,7 @@ static PyObject *py_ue_fmenu_builder_add_menu_entry(ue_PyFMenuBuilder *self, PyO
 	if (!PyArg_ParseTuple(args, "ssO|OO:add_menu_entry", &label, &tooltip, &py_callable, &py_obj, &py_uiaction_obj))
 		return nullptr;
 
-	if (!PyCallable_Check(py_callable))
+	if (!PyCalllable_Check_Extended(py_callable))
 	{
 		return PyErr_Format(PyExc_Exception, "argument is not callable");
 	}

--- a/Source/UnrealEnginePython/Private/Slate/UEPyFToolBarBuilder.cpp
+++ b/Source/UnrealEnginePython/Private/Slate/UEPyFToolBarBuilder.cpp
@@ -37,7 +37,7 @@ static PyObject *py_ue_ftool_bar_builder_add_tool_bar_button(ue_PyFToolBarBuilde
 		return PyErr_Format(PyExc_Exception, "argument is not a FSlateIcon");
 	}
 
-	if (!PyCallable_Check(py_callable)) {
+	if (!PyCalllable_Check_Extended(py_callable)) {
 		return PyErr_Format(PyExc_Exception, "argument is not callable");
 	}
 

--- a/Source/UnrealEnginePython/Private/Slate/UEPySButton.cpp
+++ b/Source/UnrealEnginePython/Private/Slate/UEPySButton.cpp
@@ -27,7 +27,7 @@ static PyObject *py_ue_sbutton_bind_on_clicked(ue_PySButton *self, PyObject * ar
 		return NULL;
 	}
 
-	if (!PyCallable_Check(py_callable))
+	if (!PyCalllable_Check_Extended(py_callable))
 	{
 		return PyErr_Format(PyExc_Exception, "argument is not callable");
 	}

--- a/Source/UnrealEnginePython/Private/Slate/UEPySPythonMultiColumnTableRow.h
+++ b/Source/UnrealEnginePython/Private/Slate/UEPySPythonMultiColumnTableRow.h
@@ -22,7 +22,7 @@ public:
         SMultiColumnTableRow<TSharedPtr<struct FPythonItem> >::Construct(FSuperRowType::FArguments(), InOwnerTableView);
     }
 
-    virtual TSharedRef<SWidget> GenerateWidgetForColumn( const FName& ColumnName ) override
+    TSharedRef<SWidget> SPythonMultiColumnTableRow::GenerateWidgetForColumn(const FName& ColumnName)
     {
         FScopePythonGIL gil;
 
@@ -30,7 +30,7 @@ public:
             return SNullWidget::NullWidget;
 
         PyObject *py_callable_generate_widget_for_column = PyObject_GetAttrString(self, (char *)"generate_widget_for_column");
-        if (!PyCallable_Check(py_callable_generate_widget_for_column))
+        if (!PyCalllable_Check_Extended(py_callable_generate_widget_for_column))
         {
             UE_LOG(LogPython, Error, TEXT("generate_widget_for_column is not a callable"));
             return SNullWidget::NullWidget;
@@ -56,14 +56,15 @@ public:
         return value;
     }
 
-    virtual FReply OnMouseButtonDoubleClick(const FGeometry& InMyGeometry, const FPointerEvent& InMouseEvent) override
+
+    FReply SPythonMultiColumnTableRow::OnMouseButtonDoubleClick(const FGeometry& InMyGeometry, const FPointerEvent& InMouseEvent)
     {
         FScopePythonGIL gil;
 
         if (PyObject_HasAttrString(self, (char *)"on_mouse_button_double_click"))
         {
             PyObject *py_callable_on_mouse_button_double_click = PyObject_GetAttrString(self, (char *)"on_mouse_button_double_click");
-            if (!PyCallable_Check(py_callable_on_mouse_button_double_click))
+            if (!PyCalllable_Check_Extended(py_callable_on_mouse_button_double_click))
             {
                 UE_LOG(LogPython, Error, TEXT("on_mouse_button_double_click is not a callable"));
                 return FReply::Unhandled();

--- a/Source/UnrealEnginePython/Private/Slate/UEPySPythonShelf.cpp
+++ b/Source/UnrealEnginePython/Private/Slate/UEPySPythonShelf.cpp
@@ -85,17 +85,17 @@ static int ue_py_spython_shelf_init(ue_PySPythonShelf *self, PyObject *args, PyO
 		}
 	}
 
-	if (py_callable_double_clicked && !PyCallable_Check(py_callable_double_clicked)) {
+	if (py_callable_double_clicked && !PyCalllable_Check_Extended(py_callable_double_clicked)) {
 		PyErr_SetString(PyExc_Exception, "argument is not callable");
 		return -1;
 	}
 
-	if (py_callable_get_context_menu && !PyCallable_Check(py_callable_get_context_menu)) {
+	if (py_callable_get_context_menu && !PyCalllable_Check_Extended(py_callable_get_context_menu)) {
 		PyErr_SetString(PyExc_Exception, "argument is not callable");
 		return -1;
 	}
 
-	if (py_callable_asset_selected && !PyCallable_Check(py_callable_asset_selected)) {
+	if (py_callable_asset_selected && !PyCalllable_Check_Extended(py_callable_asset_selected)) {
 		PyErr_SetString(PyExc_Exception, "argument is not callable");
 		return -1;
 	}

--- a/Source/UnrealEnginePython/Private/Slate/UEPySPythonWidget.h
+++ b/Source/UnrealEnginePython/Private/Slate/UEPySPythonWidget.h
@@ -37,7 +37,7 @@ public:
 			return FReply::Unhandled();
 
 		PyObject *py_callable_on_key_char = PyObject_GetAttrString(self, (char *)"on_key_char");
-		if (!PyCallable_Check(py_callable_on_key_char))
+		if (!PyCalllable_Check_Extended(py_callable_on_key_char))
 		{
 			UE_LOG(LogPython, Error, TEXT("on_key_char is not a callable"));
 			return FReply::Unhandled();
@@ -67,7 +67,7 @@ public:
 			return FReply::Unhandled();
 
 		PyObject *py_callable_on_key_down = PyObject_GetAttrString(self, (char *)"on_key_down");
-		if (!PyCallable_Check(py_callable_on_key_down))
+		if (!PyCalllable_Check_Extended(py_callable_on_key_down))
 		{
 			UE_LOG(LogPython, Error, TEXT("on_key_down is not a callable"));
 			return FReply::Unhandled();
@@ -97,7 +97,7 @@ public:
 			return FReply::Unhandled();
 
 		PyObject *py_callable_on_mouse_move = PyObject_GetAttrString(self, (char *)"on_mouse_move");
-		if (!PyCallable_Check(py_callable_on_mouse_move))
+		if (!PyCalllable_Check_Extended(py_callable_on_mouse_move))
 		{
 			UE_LOG(LogPython, Error, TEXT("on_mouse_move is not a callable"));
 			return FReply::Unhandled();
@@ -127,7 +127,7 @@ public:
 			return FReply::Unhandled();
 
 		PyObject *py_callable_on_mouse_wheel = PyObject_GetAttrString(self, (char *)"on_mouse_wheel");
-		if (!PyCallable_Check(py_callable_on_mouse_wheel))
+		if (!PyCalllable_Check_Extended(py_callable_on_mouse_wheel))
 		{
 			UE_LOG(LogPython, Error, TEXT("on_mouse_wheel is not a callable"));
 			return FReply::Unhandled();
@@ -157,7 +157,7 @@ public:
 			return FReply::Unhandled();
 
 		PyObject *py_callable_on_mouse_button_down = PyObject_GetAttrString(self, (char *)"on_mouse_button_down");
-		if (!PyCallable_Check(py_callable_on_mouse_button_down))
+		if (!PyCalllable_Check_Extended(py_callable_on_mouse_button_down))
 		{
 			UE_LOG(LogPython, Error, TEXT("on_mouse_button_down is not a callable"));
 			return FReply::Unhandled();
@@ -187,7 +187,7 @@ public:
 			return FReply::Unhandled();
 
 		PyObject *py_callable_on_mouse_button_up = PyObject_GetAttrString(self, (char *)"on_mouse_button_up");
-		if (!PyCallable_Check(py_callable_on_mouse_button_up))
+		if (!PyCalllable_Check_Extended(py_callable_on_mouse_button_up))
 		{
 			UE_LOG(LogPython, Error, TEXT("on_mouse_button_up is not a callable"));
 			return FReply::Unhandled();
@@ -226,7 +226,7 @@ public:
 			return MaxLayer;
 
 		PyObject *py_callable_paint = PyObject_GetAttrString(self, (char *)"paint");
-		if (!PyCallable_Check(py_callable_paint))
+		if (!PyCalllable_Check_Extended(py_callable_paint))
 		{
 			UE_LOG(LogPython, Error, TEXT("paint is not a callable"));
 			return MaxLayer;
@@ -257,7 +257,7 @@ public:
 			return;
 
 		PyObject *py_callable_tick = PyObject_GetAttrString(self, (char *)"tick");
-		if (!PyCallable_Check(py_callable_tick))
+		if (!PyCalllable_Check_Extended(py_callable_tick))
 		{
 			UE_LOG(LogPython, Error, TEXT("tick is not a callable"));
 			return;

--- a/Source/UnrealEnginePython/Private/Slate/UEPySWidget.cpp
+++ b/Source/UnrealEnginePython/Private/Slate/UEPySWidget.cpp
@@ -122,7 +122,7 @@ static PyObject *py_ue_swidget_bind_on_mouse_button_down(ue_PySWidget *self, PyO
 		return NULL;
 	}
 
-	if (!PyCallable_Check(py_callable))
+	if (!PyCalllable_Check_Extended(py_callable))
 	{
 		return PyErr_Format(PyExc_Exception, "argument is not callable");
 	}
@@ -147,7 +147,7 @@ static PyObject *py_ue_swidget_bind_on_mouse_button_up(ue_PySWidget *self, PyObj
 		return NULL;
 	}
 
-	if (!PyCallable_Check(py_callable))
+	if (!PyCalllable_Check_Extended(py_callable))
 	{
 		return PyErr_Format(PyExc_Exception, "argument is not callable");
 	}
@@ -172,7 +172,7 @@ static PyObject *py_ue_swidget_bind_on_mouse_double_click(ue_PySWidget *self, Py
 		return NULL;
 	}
 
-	if (!PyCallable_Check(py_callable))
+	if (!PyCalllable_Check_Extended(py_callable))
 	{
 		return PyErr_Format(PyExc_Exception, "argument is not callable");
 	}
@@ -197,7 +197,7 @@ static PyObject *py_ue_swidget_bind_on_mouse_move(ue_PySWidget *self, PyObject *
 		return NULL;
 	}
 
-	if (!PyCallable_Check(py_callable))
+	if (!PyCalllable_Check_Extended(py_callable))
 	{
 		return PyErr_Format(PyExc_Exception, "argument is not callable");
 	}

--- a/Source/UnrealEnginePython/Private/Slate/UEPySWindow.cpp
+++ b/Source/UnrealEnginePython/Private/Slate/UEPySWindow.cpp
@@ -242,7 +242,7 @@ static int ue_py_swindow_init(ue_PySWindow *self, PyObject *args, PyObject *kwar
 #endif
 
 	PyObject *on_closed = ue_py_dict_get_item(kwargs, "on_closed");
-	if (on_closed && PyCallable_Check(on_closed))
+	if (on_closed && PyCalllable_Check_Extended(on_closed))
 	{
 		FOnWindowClosed handler;
 		UPythonSlateDelegate *py_delegate = NewObject<UPythonSlateDelegate>();

--- a/Source/UnrealEnginePython/Private/Slate/UEPySlate.cpp
+++ b/Source/UnrealEnginePython/Private/Slate/UEPySlate.cpp
@@ -1228,7 +1228,7 @@ PyObject *py_unreal_engine_add_menu_extension(PyObject * self, PyObject * args)
 	if (!menu_extension_interface)
 		return PyErr_Format(PyExc_Exception, "module %s is not supported", module);
 
-	if (!PyCallable_Check(py_callable))
+	if (!PyCalllable_Check_Extended(py_callable))
 		return PyErr_Format(PyExc_Exception, "argument is not callable");
 
 	TSharedRef<FPythonSlateCommands> *commands = new TSharedRef<FPythonSlateCommands>(new FPythonSlateCommands());
@@ -1261,7 +1261,7 @@ PyObject *py_unreal_engine_add_menu_bar_extension(PyObject * self, PyObject * ar
 
 	FLevelEditorModule &ExtensibleModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
 
-	if (!PyCallable_Check(py_callable))
+	if (!PyCalllable_Check_Extended(py_callable))
 		return PyErr_Format(PyExc_Exception, "argument is not callable");
 
 	TSharedRef<FPythonSlateCommands> *commands = new TSharedRef<FPythonSlateCommands>(new FPythonSlateCommands());
@@ -1294,7 +1294,7 @@ PyObject *py_unreal_engine_add_tool_bar_extension(PyObject * self, PyObject * ar
 
 	FLevelEditorModule &ExtensibleModule = FModuleManager::LoadModuleChecked<FLevelEditorModule>("LevelEditor");
 
-	if (!PyCallable_Check(py_callable))
+	if (!PyCalllable_Check_Extended(py_callable))
 		return PyErr_Format(PyExc_Exception, "argument is not callable");
 
 	TSharedRef<FPythonSlateCommands> *commands = new TSharedRef<FPythonSlateCommands>(new FPythonSlateCommands());
@@ -1322,7 +1322,7 @@ PyObject *py_unreal_engine_add_asset_view_context_menu_extension(PyObject * self
 		return NULL;
 	}
 
-	if (!PyCallable_Check(py_callable))
+	if (!PyCalllable_Check_Extended(py_callable))
 		return PyErr_Format(PyExc_Exception, "argument is not callable");
 
 	FContentBrowserModule &ContentBrowser = FModuleManager::LoadModuleChecked<FContentBrowserModule>("ContentBrowser");
@@ -1350,7 +1350,7 @@ PyObject *py_unreal_engine_register_nomad_tab_spawner(PyObject * self, PyObject 
 		return NULL;
 	}
 
-	if (!PyCallable_Check(py_callable))
+	if (!PyCalllable_Check_Extended(py_callable))
 		return PyErr_Format(PyExc_Exception, "argument is not callable");
 
 	FOnSpawnTab spawn_tab;
@@ -1455,7 +1455,7 @@ PyObject *py_unreal_engine_open_color_picker(PyObject *self, PyObject *args, PyO
 		return nullptr;
 	}
 
-	if (!PyCallable_Check(py_callable_on_color_committed))
+	if (!PyCalllable_Check_Extended(py_callable_on_color_committed))
 	{
 		return PyErr_Format(PyExc_Exception, "on_color_committed must be a callable");
 	}

--- a/Source/UnrealEnginePython/Private/Slate/UEPySlate.h
+++ b/Source/UnrealEnginePython/Private/Slate/UEPySlate.h
@@ -163,7 +163,7 @@ ue_PySWidget *ue_py_get_swidget(TSharedRef<SWidget> s_widget);
 {\
 	PyObject *value = ue_py_dict_get_item(kwargs, _param);\
 	if (value) {\
-		if (PyCallable_Check(value)) {\
+		if (PyCalllable_Check_Extended(value)) {\
 			_base handler;\
 			UPythonSlateDelegate *py_delegate = NewObject<UPythonSlateDelegate>();\
 			py_delegate->SetPyCallable(value);\

--- a/Source/UnrealEnginePython/Private/UObject/UEPyInput.cpp
+++ b/Source/UnrealEnginePython/Private/UObject/UEPyInput.cpp
@@ -380,7 +380,7 @@ PyObject *py_ue_bind_action(ue_PyUObject *self, PyObject * args)
 		return NULL;
 	}
 
-	if (!PyCallable_Check(py_callable))
+	if (!PyCalllable_Check_Extended(py_callable))
 	{
 		return PyErr_Format(PyExc_Exception, "object is not a callable");
 	}
@@ -433,7 +433,7 @@ PyObject *py_ue_bind_axis(ue_PyUObject *self, PyObject * args)
 		return NULL;
 	}
 
-	if (!PyCallable_Check(py_callable))
+	if (!PyCalllable_Check_Extended(py_callable))
 	{
 		return PyErr_Format(PyExc_Exception, "object is not a callable");
 	}
@@ -487,7 +487,7 @@ PyObject *py_ue_bind_key(ue_PyUObject *self, PyObject * args)
 		return NULL;
 	}
 
-	if (!PyCallable_Check(py_callable))
+	if (!PyCalllable_Check_Extended(py_callable))
 	{
 		return PyErr_Format(PyExc_Exception, "object is not a callable");
 	}

--- a/Source/UnrealEnginePython/Public/UnrealEnginePython.h
+++ b/Source/UnrealEnginePython/Public/UnrealEnginePython.h
@@ -12,6 +12,9 @@
 #include "Runtime/SlateCore/Public/Styling/ISlateStyle.h"
 #include "Runtime/SlateCore/Public/Styling/SlateStyle.h"
 
+// We need to make sure reference structs do not mistaken for callable
+#define PyCalllable_Check_Extended(value) PyCallable_Check(value) && py_ue_is_uscriptstruct(value) == nullptr
+
 DECLARE_LOG_CATEGORY_EXTERN(LogPython, Log, All);
 
 


### PR DESCRIPTION
…iptstructs which are mutable/reference structs

  -Without it, slate argument binding has errors bc it tries to bind delegates to the uscriptstructs