### PR TITLE
Fixed all 4.19 warnings.

### DIFF
--- a/Source/UnrealEnginePython/Private/UEPyEngine.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyEngine.cpp
@@ -5,6 +5,8 @@
 #include "Kismet/KismetSystemLibrary.h"
 #include "Kismet/KismetMathLibrary.h"
 
+#include "HAL/PlatformApplicationMisc.h"
+
 #include "Developer/DesktopPlatform/Public/IDesktopPlatform.h"
 #include "Developer/DesktopPlatform/Public/DesktopPlatformModule.h"
 #if WITH_EDITOR
@@ -165,12 +167,12 @@ PyObject *py_unreal_engine_get_up_vector(PyObject * self, PyObject * args)
 
 PyObject *py_unreal_engine_get_content_dir(PyObject * self, PyObject * args)
 {
-	return PyUnicode_FromString(TCHAR_TO_UTF8(*FPaths::GameContentDir()));
+	return PyUnicode_FromString(TCHAR_TO_UTF8(*FPaths::ProjectContentDir()));
 }
 
 PyObject *py_unreal_engine_get_game_saved_dir(PyObject * self, PyObject * args)
 {
-	return PyUnicode_FromString(TCHAR_TO_UTF8(*FPaths::GameSavedDir()));
+	return PyUnicode_FromString(TCHAR_TO_UTF8(*FPaths::ProjectSavedDir()));
 }
 
 PyObject * py_unreal_engine_get_game_user_developer_dir(PyObject *, PyObject *)
@@ -1237,13 +1239,13 @@ PyObject *py_unreal_engine_clipboard_copy(PyObject * self, PyObject * args)
 		return nullptr;
 	}
 
-	FGenericPlatformMisc::ClipboardCopy(UTF8_TO_TCHAR(text));
+	FPlatformApplicationMisc::ClipboardCopy(UTF8_TO_TCHAR(text));
 	Py_RETURN_NONE;
 }
 
 PyObject *py_unreal_engine_clipboard_paste(PyObject * self, PyObject * args)
 {
 	FString clipboard;
-	FGenericPlatformMisc::ClipboardPaste(clipboard);
+	FPlatformApplicationMisc::ClipboardPaste(clipboard);
 	return PyUnicode_FromString(TCHAR_TO_UTF8(*clipboard));
 }

--- a/Source/UnrealEnginePython/UnrealEnginePython.Build.cs
+++ b/Source/UnrealEnginePython/UnrealEnginePython.Build.cs
@@ -125,7 +125,8 @@ public class UnrealEnginePython : ModuleRules
                 "RenderCore",
                 "MovieSceneCapture",
                 "Landscape",
-                "Foliage"
+                "Foliage",
+                "ApplicationCore"
 				// ... add private dependencies that you statically link with here ...
 			}
             );
@@ -202,7 +203,7 @@ public class UnrealEnginePython : ModuleRules
             string libPath = GetMacPythonLibFile(pythonHome);
             PublicLibraryPaths.Add(Path.GetDirectoryName(libPath));
             PublicDelayLoadDLLs.Add(libPath);
-            Definitions.Add(string.Format("UNREAL_ENGINE_PYTHON_ON_MAC"));
+            PublicDefinitions.Add(string.Format("UNREAL_ENGINE_PYTHON_ON_MAC"));
         }
         else if (Target.Platform == UnrealTargetPlatform.Linux)
         {
@@ -227,13 +228,13 @@ public class UnrealEnginePython : ModuleRules
                 PublicIncludePaths.Add(items[0]);
                 PublicAdditionalLibraries.Add(items[1]);
             }
-            Definitions.Add(string.Format("UNREAL_ENGINE_PYTHON_ON_LINUX"));
+            PublicDefinitions.Add(string.Format("UNREAL_ENGINE_PYTHON_ON_LINUX"));
         }
 
         string enableThreads = System.Environment.GetEnvironmentVariable("UEP_ENABLE_THREADS");
         if (!string.IsNullOrEmpty(enableThreads))
         {
-            Definitions.Add("UEPY_THREADING");
+            PublicDefinitions.Add("UEPY_THREADING");
             System.Console.WriteLine("*** Enabled Python Threads support ***");
         }
 


### PR DESCRIPTION
- FPaths::GameContentDir to FPaths::ProjectContentDir
- FPaths::GameSavedDir to FPaths::ProjectSavedDir
- FGenericPlatformMisc::ClipboardCopy to FPlatformApplicationMisc::ClipboardCopy
- FGenericPlatformMisc::ClipboardPaste to FPlatformApplicationMisc::ClipboardPaste
Note: Included "ApplicationCore" in PrivateDependencyModule for UnrealEnginePython.Build.cs to support the new copy/paste fuctions.
- Definitions to PublicDefinitions