### PR TITLE
Fix warnings / errors to allow 4.19 compilation

### DIFF
--- a/Source/PythonEditor/Private/PYRichTextSyntaxHighlighterTextLayoutMarshaller.cpp
+++ b/Source/PythonEditor/Private/PYRichTextSyntaxHighlighterTextLayoutMarshaller.cpp
@@ -239,7 +239,7 @@ const TCHAR* BuiltInKeywords[] =
 TSharedRef< FPYRichTextSyntaxHighlighterTextLayoutMarshaller > FPYRichTextSyntaxHighlighterTextLayoutMarshaller::Create(const FSyntaxTextStyle& InSyntaxTextStyle)
 {
 	TArray<FPythonSyntaxTokenizer::FRule> TokenizerRules;
-	
+
 	// operators
 	for(const auto& Operator : Operators)
 	{
@@ -304,14 +304,14 @@ void FPYRichTextSyntaxHighlighterTextLayoutMarshaller::ParseTokens(const FString
 					hasNextChar = true;
 				}
 			}
-			
+
 			const FTextRange ModelRange(ModelString->Len(), ModelString->Len() + TokenText.Len());
 			ModelString->Append(TokenText);
 
 			FRunInfo RunInfo(TEXT("SyntaxHighlight.PY.Normal"));
 			FTextBlockStyle TextBlockStyle = SyntaxTextStyle.NormalTextStyle;
 
-			const bool bIsWhitespace = FString(TokenText).TrimTrailing().IsEmpty();
+			const bool bIsWhitespace = FString(TokenText).TrimEnd().IsEmpty();
 			if(!bIsWhitespace)
 			{
 				bool bHasMatchedSyntax = false;
@@ -398,7 +398,7 @@ void FPYRichTextSyntaxHighlighterTextLayoutMarshaller::ParseTokens(const FString
 					}
 
 				}
-				
+
 				// It's possible that we fail to match a syntax token if we're in a state where it isn't parsed
 				// In this case, we treat it as a literal token
 				if(Token.Type == FPythonSyntaxTokenizer::ETokenType::Literal || !bHasMatchedSyntax)

--- a/Source/UnrealEnginePython/Private/PyCommandlet.cpp
+++ b/Source/UnrealEnginePython/Private/PyCommandlet.cpp
@@ -30,7 +30,7 @@ int32 UPyCommandlet::Main(const FString& CommandLine)
 	const FRegexPattern myPattern(RegexString);
 	FRegexMatcher myMatcher(myPattern, *CommandLine);
 	myMatcher.FindNext();
-	FString PyCommandLine = myMatcher.GetCaptureGroup(0).Trim().TrimTrailing();
+	FString PyCommandLine = myMatcher.GetCaptureGroup(0).TrimStart().TrimEnd();
 
 	TArray<FString> PyArgv;
 	PyArgv.Add(FString());

--- a/Source/UnrealEnginePython/Private/UEPyEngine.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyEngine.cpp
@@ -5,6 +5,10 @@
 #include "Kismet/KismetSystemLibrary.h"
 #include "Kismet/KismetMathLibrary.h"
 
+#if ENGINE_MINOR_VERSION > 18
+#  include "HAL/PlatformApplicationMisc.h"
+#endif
+
 #include "Developer/DesktopPlatform/Public/IDesktopPlatform.h"
 #include "Developer/DesktopPlatform/Public/DesktopPlatformModule.h"
 #if WITH_EDITOR
@@ -165,12 +169,12 @@ PyObject *py_unreal_engine_get_up_vector(PyObject * self, PyObject * args)
 
 PyObject *py_unreal_engine_get_content_dir(PyObject * self, PyObject * args)
 {
-	return PyUnicode_FromString(TCHAR_TO_UTF8(*FPaths::GameContentDir()));
+	return PyUnicode_FromString(TCHAR_TO_UTF8(*FPaths::ProjectContentDir()));
 }
 
 PyObject *py_unreal_engine_get_game_saved_dir(PyObject * self, PyObject * args)
 {
-	return PyUnicode_FromString(TCHAR_TO_UTF8(*FPaths::GameSavedDir()));
+	return PyUnicode_FromString(TCHAR_TO_UTF8(*FPaths::ProjectSavedDir()));
 }
 
 PyObject * py_unreal_engine_get_game_user_developer_dir(PyObject *, PyObject *)
@@ -297,7 +301,7 @@ PyObject *py_unreal_engine_unload_package(PyObject * self, PyObject * args)
 	FText outErrorMsg;
 	if (!PackageTools::UnloadPackages({ packageToUnload }, outErrorMsg))
 	{
-		return PyErr_Format(PyExc_Exception, TCHAR_TO_UTF8(*outErrorMsg.ToString()));
+		return PyErr_Format(PyExc_Exception, "%s", TCHAR_TO_UTF8(*outErrorMsg.ToString()));
 	}
 
 	Py_RETURN_NONE;
@@ -1237,13 +1241,24 @@ PyObject *py_unreal_engine_clipboard_copy(PyObject * self, PyObject * args)
 		return nullptr;
 	}
 
+#if ENGINE_MINOR_VERSION < 19
 	FGenericPlatformMisc::ClipboardCopy(UTF8_TO_TCHAR(text));
+#else
+	FPlatformApplicationMisc::ClipboardCopy(UTF8_TO_TCHAR(text));
+#endif
+
 	Py_RETURN_NONE;
 }
 
 PyObject *py_unreal_engine_clipboard_paste(PyObject * self, PyObject * args)
 {
 	FString clipboard;
+
+#if ENGINE_MINOR_VERSION < 19
 	FGenericPlatformMisc::ClipboardPaste(clipboard);
+#else
+	FPlatformApplicationMisc::ClipboardPaste(clipboard);
+#endif
+
 	return PyUnicode_FromString(TCHAR_TO_UTF8(*clipboard));
 }

--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -755,7 +755,7 @@ static PyMethodDef ue_PyUObject_methods[] = {
 	{ "has_world", (PyCFunction)py_ue_has_world, METH_VARARGS, "" },
 
 	{ "get_game_viewport", (PyCFunction)py_ue_get_game_viewport, METH_VARARGS, "" },
-		
+
 	{ "game_viewport_client_set_rendering_flag", (PyCFunction)py_ue_game_viewport_client_set_rendering_flag, METH_VARARGS, "" },
 
 	{ "get_world_location_at_distance_along_spline", (PyCFunction)py_ue_get_world_location_at_distance_along_spline, METH_VARARGS, "" },
@@ -2602,7 +2602,7 @@ PyObject *py_ue_ufunction_call(UFunction *u_function, UObject *u_obj, PyObject *
 		{
 			if (!prop->IsInContainer(u_function->ParmsSize))
 			{
-				return PyErr_Format(PyExc_Exception, "Attempting to import func param property that's out of bounds. %s", *u_function->GetName());
+				return PyErr_Format(PyExc_Exception, "Attempting to import func param property that's out of bounds. %s", TCHAR_TO_UTF8(*u_function->GetName()));
 			}
 #if WITH_EDITOR
 			FString default_key = FString("CPP_Default_") + prop->GetName();
@@ -3145,7 +3145,7 @@ bool do_ue_py_check_childstruct(PyObject *py_obj, UScriptStruct* parent_u_struct
 #if PY_MAJOR_VERSION >= 3
 static PyObject *init_unreal_engine()
 {
-	
+
 	PyObject *new_unreal_engine_module = PyModule_Create(&unreal_engine_module);
 	if (!new_unreal_engine_module)
 		return nullptr;

--- a/Source/UnrealEnginePython/Private/UObject/UEPyPhysics.cpp
+++ b/Source/UnrealEnginePython/Private/UObject/UEPyPhysics.cpp
@@ -137,7 +137,7 @@ PyObject *py_ue_add_angular_impulse(ue_PyUObject * self, PyObject * args)
 	if (py_obj_b_vel_change && PyObject_IsTrue(py_obj_b_vel_change))
 		b_vel_change = true;
 
-	primitive->AddAngularImpulse(impulse, f_bone_name, b_vel_change);
+	primitive->AddAngularImpulseInRadians(impulse, f_bone_name, b_vel_change);
 
 	Py_INCREF(Py_None);
 	return Py_None;
@@ -237,7 +237,7 @@ PyObject *py_ue_add_torque(ue_PyUObject * self, PyObject * args)
 	if (py_obj_b_accel_change && PyObject_IsTrue(py_obj_b_accel_change))
 		b_accel_change = true;
 
-	primitive->AddTorque(torque, f_bone_name, b_accel_change);
+	primitive->AddTorqueInRadians(torque, f_bone_name, b_accel_change);
 
 	Py_INCREF(Py_None);
 	return Py_None;
@@ -369,7 +369,7 @@ PyObject *py_ue_set_physics_angular_velocity(ue_PyUObject * self, PyObject * arg
 		f_bone_name = FName(UTF8_TO_TCHAR(bone_name));
 	}
 
-	primitive->SetPhysicsAngularVelocity(new_ang_vel, add_to_current, f_bone_name);
+	primitive->SetPhysicsAngularVelocityInDegrees(new_ang_vel, add_to_current, f_bone_name);
 
 	Py_INCREF(Py_None);
 	return Py_None;

--- a/Source/UnrealEnginePython/Private/UnrealEnginePython.cpp
+++ b/Source/UnrealEnginePython/Private/UnrealEnginePython.cpp
@@ -442,7 +442,7 @@ FString FUnrealEnginePythonModule::Pep8ize(FString Code)
 	return NewCode;
 }
 
-// run a python string in a new sub interpreter 
+// run a python string in a new sub interpreter
 void FUnrealEnginePythonModule::RunStringSandboxed(char *str)
 {
 	FScopePythonGIL gil;

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFSoftSkinVertex.h
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFSoftSkinVertex.h
@@ -6,6 +6,7 @@
 #if ENGINE_MINOR_VERSION > 18
 
 #include "Runtime/Engine/Public/Rendering/SkeletalMeshLODModel.h"
+#include "Runtime/Engine/Public/Rendering/SkeletalMeshTypes.h"
 
 #endif
 


### PR DESCRIPTION
1.  Fixed `TrimEnd` `TrimStart`
2. Fixed Project vs Game `ContentDir` and `SavedDir`
3. Other 4.18 -> 4.19 migrations