### PR TITLE
Add graph_add_node_dynamic_cast

### DIFF
--- a/Source/UnrealEnginePython/Private/Blueprint/UEPyEdGraph.h
+++ b/Source/UnrealEnginePython/Private/Blueprint/UEPyEdGraph.h
@@ -13,6 +13,7 @@ PyObject *py_ue_graph_add_node_custom_event(ue_PyUObject *, PyObject *);
 PyObject *py_ue_graph_add_node_variable_get(ue_PyUObject *, PyObject *);
 PyObject *py_ue_graph_add_node_variable_set(ue_PyUObject *, PyObject *);
 PyObject *py_ue_graph_add_node(ue_PyUObject *, PyObject *);
+PyObject *py_ue_graph_add_node_dynamic_cast(ue_PyUObject *, PyObject *);
 PyObject *py_ue_graph_add_node_event(ue_PyUObject *, PyObject *);
 
 PyObject *py_ue_graph_get_good_place_for_new_node(ue_PyUObject *, PyObject *);

--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -576,6 +576,7 @@ static PyMethodDef ue_PyUObject_methods[] = {
 	{ "graph_add_node_variable_set", (PyCFunction)py_ue_graph_add_node_variable_set, METH_VARARGS, "" },
 
 	{ "graph_add_node", (PyCFunction)py_ue_graph_add_node, METH_VARARGS, "" },
+	{ "graph_add_node_dynamic_cast", (PyCFunction)py_ue_graph_add_node_dynamic_cast, METH_VARARGS, "" },
 	{ "graph_add_node_event", (PyCFunction)py_ue_graph_add_node_event, METH_VARARGS, "" },
 	{ "graph_get_good_place_for_new_node", (PyCFunction)py_ue_graph_get_good_place_for_new_node, METH_VARARGS, "" },
 


### PR DESCRIPTION
This PR adds a new method for creating a DynamicCast node in a node graph. It takes the type to cast to, and will ensure that all pins are created properly.