### PR TITLE
Allow Class objects to be assigned to Properties that take a UObject

### DIFF
--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -2437,6 +2437,14 @@ bool ue_py_convert_pyobject(PyObject *py_obj, UProperty *prop, uint8 *buffer, in
 				casted_prop_weak_object->SetPropertyValue_InContainer(buffer, FWeakObjectPtr(ue_obj->ue_object), index);
 				return true;
 			}
+			else if (auto casted_prop = Cast<UObjectPropertyBase>(prop))
+			{
+				// ensure the object type is correct, otherwise crash could happen (soon or later)
+				if (!ue_obj->ue_object->IsA(casted_prop->PropertyClass))
+					return false;
+				casted_prop->SetObjectPropertyValue_InContainer(buffer, ue_obj->ue_object, index);
+				return true;
+			}
 
 			return false;
 		}


### PR DESCRIPTION
This is to fix up a snag I hit when working with a `K2Node_CallFunction`.

I was attempting to run the following code, which I felt should work. This was to call a function on another blueprint.

    callFuncNode = K2Node_CallFunction()
    callFuncNode.FunctionReference = MemberReference( MemberName="MyFunction", MemberParent=otherBP.GeneratedClass )

This failed with an error saying `invalid value for UProperty`.

This is because MemberReference.MemberParent is of type UObject, rather than UClass, as it can take various types of object, one of which is a UClass (as in this case)

What this PR does is allow a UClass to be assigned to a UObjectPropertyBase property as well as the existing property types.