### PR TITLE
Apply (char *) to static strings, exclude TSharedRef<IPlugin>plugin f…

### DIFF
--- a/Source/PythonAutomation/Private/PythonAutomationModule.cpp
+++ b/Source/PythonAutomation/Private/PythonAutomationModule.cpp
@@ -9,7 +9,7 @@ IMPLEMENT_MODULE(FPythonAutomationModule, PythonAutomation);
 
 void FPythonAutomationModule::StartupModule()
 {
-	PyObject *py_automation_module = ue_py_register_module("unreal_engine.automation");
+	PyObject *py_automation_module = ue_py_register_module((char *)"unreal_engine.automation");
 	ue_python_init_fautomation_editor_common_utils(py_automation_module);
 }
 

--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -1552,9 +1552,9 @@ void unreal_engine_init_py_module()
 
 	ue_python_init_ivoice_capture(new_unreal_engine_module);
 
-	ue_py_register_magic_module("unreal_engine.classes", py_ue_new_uclassesimporter);
-	ue_py_register_magic_module("unreal_engine.enums", py_ue_new_enumsimporter);
-	ue_py_register_magic_module("unreal_engine.structs", py_ue_new_ustructsimporter);
+	ue_py_register_magic_module((char *)"unreal_engine.classes", py_ue_new_uclassesimporter);
+	ue_py_register_magic_module((char *)"unreal_engine.enums", py_ue_new_enumsimporter);
+	ue_py_register_magic_module((char *)"unreal_engine.structs", py_ue_new_ustructsimporter);
 
 
 	PyDict_SetItemString(unreal_engine_dict, "ENGINE_MAJOR_VERSION", PyLong_FromLong(ENGINE_MAJOR_VERSION));

--- a/Source/UnrealEnginePython/Private/UnrealEnginePython.cpp
+++ b/Source/UnrealEnginePython/Private/UnrealEnginePython.cpp
@@ -300,6 +300,7 @@ void FUnrealEnginePythonModule::StartupModule()
 		ScriptsPaths.Add(ProjectScriptsPath);
 	}
 
+  #if WITH_EDITOR
 	for (TSharedRef<IPlugin>plugin : IPluginManager::Get().GetEnabledPlugins())
 	{
 		FString PluginScriptsPath = FPaths::Combine(plugin->GetContentDir(), UTF8_TO_TCHAR("Scripts"));
@@ -308,6 +309,7 @@ void FUnrealEnginePythonModule::StartupModule()
 			ScriptsPaths.Add(PluginScriptsPath);
 		}
 	}
+  #endif
 
 	if (ZipPath.IsEmpty())
 	{
@@ -461,7 +463,7 @@ FString FUnrealEnginePythonModule::Pep8ize(FString Code)
 	return NewCode;
 }
 
-// run a python string in a new sub interpreter 
+// run a python string in a new sub interpreter
 void FUnrealEnginePythonModule::RunStringSandboxed(char *str)
 {
 	FScopePythonGIL gil;
@@ -684,4 +686,3 @@ PyObject *ue_py_register_module(char *name)
 #undef LOCTEXT_NAMESPACE
 
 IMPLEMENT_MODULE(FUnrealEnginePythonModule, UnrealEnginePython)
-

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFSlowTask.cpp
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFSlowTask.cpp
@@ -74,7 +74,7 @@ static PyObject *py_ue_fslowtask_make_dialog(ue_PyFSlowTask *self, PyObject * ar
 static PyObject *py_ue_fslowtask_enter_progress_frame(ue_PyFSlowTask *self, PyObject * args)
 {
 	float expected_work_this_frame = 1.0;
-	char *text = "";
+	char *text = (char *)"";
 	if(!PyArg_ParseTuple(args, "|fs:enter_progress_frame", &expected_work_this_frame, &text))
 	{
 		return nullptr;
@@ -153,7 +153,7 @@ static PyTypeObject ue_PyFSlowTaskType = {
 static int py_ue_fslowtask_init(ue_PyFSlowTask *self, PyObject * args)
 {
 	float amount_of_work;
-	char *default_message = "";
+	char *default_message = (char *)"";
 	PyObject *py_enabled = nullptr;
 	if(!PyArg_ParseTuple(args, "f|sO:__init__", &amount_of_work, &default_message, &py_enabled))
 	{


### PR DESCRIPTION
Apply (char *) to static strings, exclude TSharedRef<IPlugin>plugin from non editor builds to resolve issue 412.

Adding (char*) to static strings fixed the editor build.  Excluding TSharedRef... fixed the command line build.

Tested on Ubuntu for editor and automated builds, but not on Windows or Mac.

It's just a couple lines changed, but feel free to edit.  And, thanks for the tips in the issue report!