### PR TITLE
Fix headers for clang 6 build

### DIFF
--- a/Source/PythonConsole/Private/PyFbxFactory.cpp
+++ b/Source/PythonConsole/Private/PyFbxFactory.cpp
@@ -1,6 +1,6 @@
+#include "PyFbxFactory.h"
 #include "PythonConsolePrivatePCH.h"
 
-#include "PyFbxFactory.h"
 #include "FbxMeshUtils.h"
 
 UPyFbxFactory::UPyFbxFactory(const FObjectInitializer& ObjectInitializer)

--- a/Source/PythonConsole/Private/PythonConsoleModule.cpp
+++ b/Source/PythonConsole/Private/PythonConsoleModule.cpp
@@ -1,5 +1,6 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
+#include "PythonConsoleModule.h"
 #include "PythonConsolePrivatePCH.h"
 #include "SPythonConsole.h"
 #include "SPythonLog.h"

--- a/Source/PythonConsole/Private/PythonScriptFactory.cpp
+++ b/Source/PythonConsole/Private/PythonScriptFactory.cpp
@@ -1,6 +1,6 @@
+#include "PythonScriptFactory.h"
 #include "PythonConsolePrivatePCH.h"
 
-#include "PythonScriptFactory.h"
 #include "PythonScript.h"
 
 UPythonScriptFactory::UPythonScriptFactory(const FObjectInitializer& ObjectInitializer) : Super(ObjectInitializer) {

--- a/Source/PythonConsole/Private/SPythonConsole.cpp
+++ b/Source/PythonConsole/Private/SPythonConsole.cpp
@@ -1,8 +1,8 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
+#include "SPythonConsole.h"
 #include "PythonConsolePrivatePCH.h"
 #include "PythonConsoleModule.h"
-#include "SPythonConsole.h"
 #include "SPythonLog.h"
 
 namespace PythonConsoleDefs

--- a/Source/PythonConsole/Private/SPythonLog.cpp
+++ b/Source/PythonConsole/Private/SPythonLog.cpp
@@ -1,7 +1,7 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
-#include "PythonConsolePrivatePCH.h"
 #include "SPythonLog.h"
+#include "PythonConsolePrivatePCH.h"
 #include "SScrollBorder.h"
 #include "GameFramework/GameMode.h"
 #include "Engine/LocalPlayer.h"

--- a/Source/PythonEditor/Private/DirectoryScanner.cpp
+++ b/Source/PythonEditor/Private/DirectoryScanner.cpp
@@ -1,7 +1,7 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
-#include "PythonEditorPrivatePCH.h"
 #include "DirectoryScanner.h"
+#include "PythonEditorPrivatePCH.h"
 #include "PythonProjectItem.h"
 
 TArray<FDirectoryScannerCommand*> FDirectoryScanner::CommandQueue;

--- a/Source/PythonEditor/Private/PYRichTextSyntaxHighlighterTextLayoutMarshaller.cpp
+++ b/Source/PythonEditor/Private/PYRichTextSyntaxHighlighterTextLayoutMarshaller.cpp
@@ -1,7 +1,7 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
-#include "PythonEditorPrivatePCH.h"
 #include "PYRichTextSyntaxHighlighterTextLayoutMarshaller.h"
+#include "PythonEditorPrivatePCH.h"
 #include "WhiteSpaceTextRun.h"
 
 FPYRichTextSyntaxHighlighterTextLayoutMarshaller::FPYRichTextSyntaxHighlighterTextLayoutMarshaller(TSharedPtr< FPythonSyntaxTokenizer > InTokenizer, const FSyntaxTextStyle& InSyntaxTextStyle)

--- a/Source/PythonEditor/Private/PythonEditorCustomization.cpp
+++ b/Source/PythonEditor/Private/PythonEditorCustomization.cpp
@@ -1,7 +1,7 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
-#include "PythonEditorPrivatePCH.h"
 #include "PythonEditorCustomization.h"
+#include "PythonEditorPrivatePCH.h"
 
 UPythonEditorCustomization::UPythonEditorCustomization(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)

--- a/Source/PythonEditor/Private/PythonEditorStyle.cpp
+++ b/Source/PythonEditor/Private/PythonEditorStyle.cpp
@@ -1,5 +1,6 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
+#include "PythonEditorStyle.h"
 #include "PythonEditorPrivatePCH.h"
 #include "EditorStyleSet.h"
 

--- a/Source/PythonEditor/Private/PythonProject.cpp
+++ b/Source/PythonEditor/Private/PythonProject.cpp
@@ -1,5 +1,6 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
+#include "PythonProject.h"
 #include "PythonEditorPrivatePCH.h"
 
 

--- a/Source/PythonEditor/Private/PythonProjectEditor.cpp
+++ b/Source/PythonEditor/Private/PythonProjectEditor.cpp
@@ -1,5 +1,6 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
+#include "PythonProjectEditor.h"
 #include "PythonEditorPrivatePCH.h"
 #include "SPythonEditor.h"
 #include "SPythonProjectEditor.h"

--- a/Source/PythonEditor/Private/PythonProjectEditorCommands.cpp
+++ b/Source/PythonEditor/Private/PythonProjectEditorCommands.cpp
@@ -1,5 +1,6 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
+#include "PythonProjectEditorCommands.h"
 #include "PythonEditorPrivatePCH.h"
 
 

--- a/Source/PythonEditor/Private/PythonProjectEditorToolbar.cpp
+++ b/Source/PythonEditor/Private/PythonProjectEditorToolbar.cpp
@@ -1,7 +1,7 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
-#include "PythonEditorPrivatePCH.h"
 #include "PythonProjectEditorToolbar.h"
+#include "PythonEditorPrivatePCH.h"
 #include "LevelEditorActions.h"
 #include "SourceCodeNavigation.h"
 #include "EditorStyleSet.h"

--- a/Source/PythonEditor/Private/PythonProjectItem.cpp
+++ b/Source/PythonEditor/Private/PythonProjectItem.cpp
@@ -1,7 +1,7 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
-#include "PythonEditorPrivatePCH.h"
 #include "PythonProjectItem.h"
+#include "PythonEditorPrivatePCH.h"
 #include "DirectoryScanner.h"
 #include "Developer/DirectoryWatcher/Public/IDirectoryWatcher.h"
 

--- a/Source/PythonEditor/Private/PythonSyntaxTokenizer.cpp
+++ b/Source/PythonEditor/Private/PythonSyntaxTokenizer.cpp
@@ -1,7 +1,7 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
-#include "PythonEditorPrivatePCH.h"
 #include "PythonSyntaxTokenizer.h"
+#include "PythonEditorPrivatePCH.h"
 #include "BreakIterator.h"
 
 TSharedRef< FPythonSyntaxTokenizer > FPythonSyntaxTokenizer::Create(TArray<FRule> InRules)

--- a/Source/PythonEditor/Private/SProjectViewItem.cpp
+++ b/Source/PythonEditor/Private/SProjectViewItem.cpp
@@ -1,5 +1,6 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
+#include "SProjectViewItem.h"
 #include "PythonEditorPrivatePCH.h"
 #include "SProjectViewItem.h"
 #include "SInlineEditableTextBlock.h"

--- a/Source/PythonEditor/Private/SPythonEditableText.cpp
+++ b/Source/PythonEditor/Private/SPythonEditableText.cpp
@@ -1,7 +1,7 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
-#include "PythonEditorPrivatePCH.h"
 #include "SPythonEditableText.h"
+#include "PythonEditorPrivatePCH.h"
 
 
 void SPythonEditableText::Construct(const FArguments& InArgs)

--- a/Source/PythonEditor/Private/SPythonEditor.cpp
+++ b/Source/PythonEditor/Private/SPythonEditor.cpp
@@ -1,7 +1,7 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
-#include "PythonEditorPrivatePCH.h"
 #include "SPythonEditor.h"
+#include "PythonEditorPrivatePCH.h"
 #include "SMultiLineEditableText.h"
 #include "PYRichTextSyntaxHighlighterTextLayoutMarshaller.h"
 #include "SPythonEditableText.h"

--- a/Source/PythonEditor/Private/SPythonProjectEditor.cpp
+++ b/Source/PythonEditor/Private/SPythonProjectEditor.cpp
@@ -1,7 +1,7 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
-#include "PythonEditorPrivatePCH.h"
 #include "SPythonProjectEditor.h"
+#include "PythonEditorPrivatePCH.h"
 #include "SProjectViewItem.h"
 #include "DirectoryScanner.h"
 #include "SThrobber.h"

--- a/Source/PythonEditor/Private/WhiteSpaceTextRun.cpp
+++ b/Source/PythonEditor/Private/WhiteSpaceTextRun.cpp
@@ -1,7 +1,7 @@
 // Copyright 1998-2016 Epic Games, Inc. All Rights Reserved.
 
-#include "PythonEditorPrivatePCH.h"
 #include "WhiteSpaceTextRun.h"
+#include "PythonEditorPrivatePCH.h"
 
 TSharedRef< FWhiteSpaceTextRun > FWhiteSpaceTextRun::Create( const FRunInfo& InRunInfo, const TSharedRef< const FString >& InText, const FTextBlockStyle& Style, const FTextRange& InRange, int32 NumSpacesPerTab )
 {


### PR DESCRIPTION
Fixes these issues during the build:

```
------- Build details --------
  Using clang (/usr/bin/clang++) version '6.0.0' (string), 6 (major), 0 (minor), 0 (patch)
  Using bundled libc++ standard C++ library.
  Using lld linker
  Using llvm-ar : /usr/bin/llvm-ar
  Using fast way to relink  circularly dependent libraries (no FixDeps).
  ------------------------------
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonConsole/Private/PyFbxFactory.cpp(1): error: Expected PyFbxFactory.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonConsole/Private/PythonConsoleModule.cpp(1): error: Expected PythonConsoleModule.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonConsole/Private/PythonScriptFactory.cpp(1): error: Expected PythonScriptFactory.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonConsole/Private/SPythonConsole.cpp(1): error: Expected SPythonConsole.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonConsole/Private/SPythonLog.cpp(1): error: Expected SPythonLog.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonEditor/Private/DirectoryScanner.cpp(1): error: Expected DirectoryScanner.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonEditor/Private/PYRichTextSyntaxHighlighterTextLayoutMarshaller.cpp(1): error: Expected PYRichTextSyntaxHighlighterTextLayoutMarshaller.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonEditor/Private/PythonEditorCustomization.cpp(1): error: Expected PythonEditorCustomization.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonEditor/Private/PythonEditorStyle.cpp(1): error: Expected PythonEditorStyle.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonEditor/Private/PythonProject.cpp(1): error: Expected PythonProject.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonEditor/Private/PythonProjectEditor.cpp(1): error: Expected PythonProjectEditor.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonEditor/Private/PythonProjectEditorCommands.cpp(1): error: Expected PythonProjectEditorCommands.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonEditor/Private/PythonProjectEditorToolbar.cpp(1): error: Expected PythonProjectEditorToolbar.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonEditor/Private/PythonProjectItem.cpp(1): error: Expected PythonProjectItem.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonEditor/Private/PythonSyntaxTokenizer.cpp(1): error: Expected PythonSyntaxTokenizer.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonEditor/Private/SProjectViewItem.cpp(1): error: Expected SProjectViewItem.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonEditor/Private/SPythonEditableText.cpp(1): error: Expected SPythonEditableText.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonEditor/Private/SPythonEditor.cpp(1): error: Expected SPythonEditor.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonEditor/Private/SPythonProjectEditor.cpp(1): error: Expected SPythonProjectEditor.h to be first header included.
  /home/user/temp/HostProject/Plugins/UnrealEnginePython/Source/PythonEditor/Private/WhiteSpaceTextRun.cpp(1): error: Expected WhiteSpaceTextRun.h to be first header included.
  ERROR: Build canceled.

```