### PR TITLE
add support for native types like FVector in method params

### DIFF
--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -3258,6 +3258,42 @@ UFunction *unreal_engine_add_function(UClass *u_class, char *name, PyObject *py_
 				{
 					prop = NewObject<UIntProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
 				}
+				else if ((PyTypeObject *)py_return_value == &ue_PyFVectorType)
+				{
+					UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
+					prop_struct->Struct = TBaseStructure<FVector>::Get();
+					prop = prop_struct;
+				}
+				else if ((PyTypeObject *)py_return_value == &ue_PyFRotatorType)
+				{
+					UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
+					prop_struct->Struct = TBaseStructure<FRotator>::Get();
+					prop = prop_struct;
+				}
+				else if ((PyTypeObject *)py_return_value == &ue_PyFLinearColorType)
+				{
+					UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
+					prop_struct->Struct = TBaseStructure<FLinearColor>::Get();
+					prop = prop_struct;
+				}
+				else if ((PyTypeObject *)py_return_value == &ue_PyFColorType)
+				{
+					UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
+					prop_struct->Struct = TBaseStructure<FColor>::Get();
+					prop = prop_struct;
+				}
+				else if ((PyTypeObject *)py_return_value == &ue_PyFTransformType)
+				{
+					UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
+					prop_struct->Struct = TBaseStructure<FTransform>::Get();
+					prop = prop_struct;
+				}
+				else if ((PyTypeObject *)py_return_value == &ue_PyFQuatType)
+				{
+					UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
+					prop_struct->Struct = TBaseStructure<FQuat>::Get();
+					prop = prop_struct;
+				}
 			}
 			else if (ue_PyUObject *py_obj = ue_is_pyuobject(py_return_value))
 			{
@@ -3286,7 +3322,7 @@ UFunction *unreal_engine_add_function(UClass *u_class, char *name, PyObject *py_
 					}
 				}
 			}
-			// TODO add native types (like vectors, rotators...)
+
 			if (prop)
 			{
 				prop->SetPropertyFlags(CPF_Parm | CPF_OutParm | CPF_ReturnParm);

--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -3151,6 +3151,42 @@ UFunction *unreal_engine_add_function(UClass *u_class, char *name, PyObject *py_
 			{
 				prop = NewObject<UIntProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
 			}
+			else if ((PyTypeObject *)value == &ue_PyFVectorType)
+			{
+				UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
+				prop_struct->Struct = TBaseStructure<FVector>::Get();
+				prop = prop_struct;
+			}
+			else if ((PyTypeObject *)value == &ue_PyFRotatorType)
+			{
+				UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
+				prop_struct->Struct = TBaseStructure<FRotator>::Get();
+				prop = prop_struct;
+			}
+			else if ((PyTypeObject *)value == &ue_PyFLinearColorType)
+			{
+				UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
+				prop_struct->Struct = TBaseStructure<FLinearColor>::Get();
+				prop = prop_struct;
+			}
+			else if ((PyTypeObject *)value == &ue_PyFColorType)
+			{
+				UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
+				prop_struct->Struct = TBaseStructure<FColor>::Get();
+				prop = prop_struct;
+			}
+			else if ((PyTypeObject *)value == &ue_PyFTransformType)
+			{
+				UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
+				prop_struct->Struct = TBaseStructure<FTransform>::Get();
+				prop = prop_struct;
+			}
+			else if ((PyTypeObject *)value == &ue_PyFQuatType)
+			{
+				UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
+				prop_struct->Struct = TBaseStructure<FQuat>::Get();
+				prop = prop_struct;
+			}
 		}
 		else if (ue_PyUObject *py_obj = ue_is_pyuobject(value))
 		{
@@ -3179,7 +3215,7 @@ UFunction *unreal_engine_add_function(UClass *u_class, char *name, PyObject *py_
 				}
 			}
 		}
-		// TODO add native types (like vectors, rotators...)
+
 		if (prop)
 		{
 			prop->SetPropertyFlags(CPF_Parm);

--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -3214,6 +3214,14 @@ UFunction *unreal_engine_add_function(UClass *u_class, char *name, PyObject *py_
 					prop = prop_base;
 				}
 			}
+            else if (py_obj->ue_object->IsA<UEnum>())
+            {
+                UEnumProperty *prop_enum = NewObject<UEnumProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
+                UNumericProperty *prop_underlying = NewObject<UByteProperty>(prop_enum, TEXT("UnderlyingType"), RF_Public);
+                prop_enum->SetEnum((UEnum*)py_obj->ue_object);
+                prop_enum->AddCppProperty(prop_underlying);
+                prop = prop_enum;
+            }
 		}
 
 		if (prop)
@@ -3321,6 +3329,14 @@ UFunction *unreal_engine_add_function(UClass *u_class, char *name, PyObject *py_
 						prop = prop_base;
 					}
 				}
+                else if (py_obj->ue_object->IsA<UEnum>())
+                {
+                    UEnumProperty *prop_enum = NewObject<UEnumProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
+                    UNumericProperty *prop_underlying = NewObject<UByteProperty>(prop_enum, TEXT("UnderlyingType"), RF_Public);
+                    prop_enum->SetEnum((UEnum*)py_obj->ue_object);
+                    prop_enum->AddCppProperty(prop_underlying);
+                    prop = prop_enum;
+                }
 			}
 
 			if (prop)

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFColor.cpp
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFColor.cpp
@@ -103,7 +103,7 @@ static PyObject *ue_PyFColor_str(ue_PyFColor *self)
 		self->color.R, self->color.G, self->color.B, self->color.A);
 }
 
-static PyTypeObject ue_PyFColorType = {
+PyTypeObject ue_PyFColorType = {
 	PyVarObject_HEAD_INIT(NULL, 0)
 	"unreal_engine.FColor", /* tp_name */
 	sizeof(ue_PyFColor), /* tp_basicsize */

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFColor.h
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFColor.h
@@ -11,6 +11,8 @@ typedef struct
 		FColor color;
 } ue_PyFColor;
 
+extern PyTypeObject ue_PyFColorType;
+
 PyObject *py_ue_new_fcolor(FColor);
 ue_PyFColor *py_ue_is_fcolor(PyObject *);
 

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFLinearColor.cpp
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFLinearColor.cpp
@@ -106,7 +106,7 @@ static PyObject *ue_PyFLinearColor_str(ue_PyFLinearColor *self)
 		PyFloat_FromDouble(self->color.A));
 }
 
-static PyTypeObject ue_PyFLinearColorType = {
+PyTypeObject ue_PyFLinearColorType = {
 	PyVarObject_HEAD_INIT(NULL, 0)
 	"unreal_engine.FLinearColor", /* tp_name */
 	sizeof(ue_PyFLinearColor), /* tp_basicsize */

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFLinearColor.h
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFLinearColor.h
@@ -11,6 +11,8 @@ typedef struct
 		FLinearColor color;
 } ue_PyFLinearColor;
 
+extern PyTypeObject ue_PyFLinearColorType;
+
 PyObject *py_ue_new_flinearcolor(FLinearColor);
 ue_PyFLinearColor *py_ue_is_flinearcolor(PyObject *);
 

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFQuat.cpp
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFQuat.cpp
@@ -152,7 +152,7 @@ static PyObject *ue_PyFQuat_str(ue_PyFQuat *self)
 		PyFloat_FromDouble(self->quat.X), PyFloat_FromDouble(self->quat.Y), PyFloat_FromDouble(self->quat.Z), PyFloat_FromDouble(self->quat.W));
 }
 
-static PyTypeObject ue_PyFQuatType = {
+PyTypeObject ue_PyFQuatType = {
 	PyVarObject_HEAD_INIT(NULL, 0)
 	"unreal_engine.FQuat", /* tp_name */
 	sizeof(ue_PyFQuat), /* tp_basicsize */

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFQuat.h
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFQuat.h
@@ -11,6 +11,8 @@ typedef struct
 		FQuat quat;
 } ue_PyFQuat;
 
+extern PyTypeObject ue_PyFQuatType;
+
 PyObject *py_ue_new_fquat(FQuat);
 ue_PyFQuat *py_ue_is_fquat(PyObject *);
 

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFRotator.cpp
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFRotator.cpp
@@ -93,7 +93,7 @@ static PyObject *ue_PyFRotator_str(ue_PyFRotator *self)
 		PyFloat_FromDouble(self->rot.Roll), PyFloat_FromDouble(self->rot.Pitch), PyFloat_FromDouble(self->rot.Yaw));
 }
 
-static PyTypeObject ue_PyFRotatorType = {
+PyTypeObject ue_PyFRotatorType = {
 	PyVarObject_HEAD_INIT(NULL, 0)
 	"unreal_engine.FRotator", /* tp_name */
 	sizeof(ue_PyFRotator), /* tp_basicsize */

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFRotator.h
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFRotator.h
@@ -10,6 +10,8 @@ typedef struct {
 	FRotator rot;
 } ue_PyFRotator;
 
+extern PyTypeObject ue_PyFRotatorType;
+
 PyObject *py_ue_new_frotator(FRotator);
 ue_PyFRotator *py_ue_is_frotator(PyObject *);
 

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFTransform.cpp
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFTransform.cpp
@@ -220,7 +220,7 @@ static PyObject *ue_PyFTransform_str(ue_PyFTransform *self)
 }
 
 
-static PyTypeObject ue_PyFTransformType = {
+PyTypeObject ue_PyFTransformType = {
 	PyVarObject_HEAD_INIT(NULL, 0)
 	"unreal_engine.FTransform", /* tp_name */
 	sizeof(ue_PyFTransform), /* tp_basicsize */

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFTransform.h
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFTransform.h
@@ -10,6 +10,8 @@ typedef struct {
 	FTransform transform;
 } ue_PyFTransform;
 
+extern PyTypeObject ue_PyFTransformType;
+
 PyObject *py_ue_new_ftransform(FTransform);
 ue_PyFTransform *py_ue_is_ftransform(PyObject *);
 

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFVector.cpp
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFVector.cpp
@@ -151,7 +151,7 @@ static PyObject *ue_PyFVector_str(ue_PyFVector *self)
 		PyFloat_FromDouble(self->vec.X), PyFloat_FromDouble(self->vec.Y), PyFloat_FromDouble(self->vec.Z));
 }
 
-static PyTypeObject ue_PyFVectorType = {
+PyTypeObject ue_PyFVectorType = {
 	PyVarObject_HEAD_INIT(NULL, 0)
 	"unreal_engine.FVector", /* tp_name */
 	sizeof(ue_PyFVector), /* tp_basicsize */

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFVector.h
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFVector.h
@@ -11,6 +11,8 @@ typedef struct
 		FVector vec;
 } ue_PyFVector;
 
+extern PyTypeObject ue_PyFVectorType;
+
 PyObject *py_ue_new_fvector(FVector);
 ue_PyFVector *py_ue_is_fvector(PyObject *);
 


### PR DESCRIPTION
Given a C++ parent class like:

```
UCLASS()
class UPYDEV_API ACActor : public AActor
{
   ...
    UFUNCTION(BlueprintCallable, BlueprintImplementableEvent)
    void ReceiveAVector(FVector newVector);
    ...
```

this patch makes it possible to have a Python subclass like:

```
import unreal_engine as ue
from unreal_engine.classes import CActor
from unreal_engine import FVector, FRotator, FLinearColor, FQuat, FColor, FTransform

class PActor(CActor):
    def ReceiveAVector(self, newVector : FVector):

```

Added support for FVector, FRotator, FLinearColor, FColor, FTransform, and FQuat.