### PR TITLE
Fixed division bug in FVector

### DIFF
--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFVector.cpp
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFVector.cpp
@@ -277,6 +277,24 @@ static PyObject *ue_py_fvector_div(ue_PyFVector *self, PyObject *value)
 	return py_ue_new_fvector(vec);
 }
 
+static PyObject *ue_py_fvector_floor_div(ue_PyFVector *self, PyObject *value)
+{
+	FVector vec = self->vec;
+	if (PyNumber_Check(value))
+	{
+		PyObject *f_value = PyNumber_Float(value);
+		float f = PyFloat_AsDouble(f_value);
+		if (f == 0)
+			return PyErr_Format(PyExc_ZeroDivisionError, "division by zero");
+		vec.X = floor(vec.X / f);
+		vec.Y = floor(vec.Y / f);
+		vec.Z = floor(vec.Z / f);
+		Py_DECREF(f_value);
+		return py_ue_new_fvector(vec);
+	}
+	return PyErr_Format(PyExc_TypeError, "value is not numeric");
+}
+
 PyNumberMethods ue_PyFVector_number_methods;
 
 static Py_ssize_t ue_py_fvector_seq_length(ue_PyFVector *self)
@@ -364,6 +382,7 @@ void ue_python_init_fvector(PyObject *ue_module)
 	ue_PyFVector_number_methods.nb_subtract = (binaryfunc)ue_py_fvector_sub;
 	ue_PyFVector_number_methods.nb_multiply = (binaryfunc)ue_py_fvector_mul;
 	ue_PyFVector_number_methods.nb_true_divide = (binaryfunc)ue_py_fvector_div;
+	ue_PyFVector_number_methods.nb_floor_divide = (binaryfunc)ue_py_fvector_floor_div;
 
 	memset(&ue_PyFVector_sequence_methods, 0, sizeof(PySequenceMethods));
 	ue_PyFVectorType.tp_as_sequence = &ue_PyFVector_sequence_methods;

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFVector.cpp
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFVector.cpp
@@ -363,7 +363,7 @@ void ue_python_init_fvector(PyObject *ue_module)
 	ue_PyFVector_number_methods.nb_add = (binaryfunc)ue_py_fvector_add;
 	ue_PyFVector_number_methods.nb_subtract = (binaryfunc)ue_py_fvector_sub;
 	ue_PyFVector_number_methods.nb_multiply = (binaryfunc)ue_py_fvector_mul;
-	ue_PyFVector_number_methods.nb_divmod = (binaryfunc)ue_py_fvector_div;
+	ue_PyFVector_number_methods.nb_true_divide = (binaryfunc)ue_py_fvector_div;
 
 	memset(&ue_PyFVector_sequence_methods, 0, sizeof(PySequenceMethods));
 	ue_PyFVectorType.tp_as_sequence = &ue_PyFVector_sequence_methods;


### PR DESCRIPTION
While working on support for FVector2D I noticed what seems to be a minor bug with FVector. Currently if you try to do this:
```py
    from unreal_engine import FVector
    v = FVector(10, 15, 18)
    print(v/3)
```

you get this error:
```py
TypeError: unsupported operand type(s) for /: 'unreal_engine.FVector' and 'int'
```

With the patch you get what you'd expect:
```py
<unreal_engine.FVector {'x': 3.3333334922790527, 'y': 5.0, 'z': 6.0}>
```