### PR TITLE
added get_static_mesh_bounds method

### DIFF
--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -751,6 +751,7 @@ static PyMethodDef ue_PyUObject_methods[] = {
 	{ "vlog_cylinder", (PyCFunction)py_ue_vlog_cylinder, METH_VARARGS, "" },
 
 	// StaticMesh
+    { "get_static_mesh_bounds", (PyCFunction)py_ue_static_mesh_get_bounds, METH_VARARGS, "" },
 #if WITH_EDITOR
 	{ "static_mesh_build", (PyCFunction)py_ue_static_mesh_build, METH_VARARGS, "" },
 	{ "static_mesh_create_body_setup", (PyCFunction)py_ue_static_mesh_create_body_setup, METH_VARARGS, "" },

--- a/Source/UnrealEnginePython/Private/UObject/UEPyStaticMesh.cpp
+++ b/Source/UnrealEnginePython/Private/UObject/UEPyStaticMesh.cpp
@@ -1,9 +1,24 @@
 #include "UEPyStaticMesh.h"
+#include "Engine/StaticMesh.h"
 
+PyObject *py_ue_static_mesh_get_bounds(ue_PyUObject *self, PyObject * args)
+{
+    ue_py_check(self);
+    UStaticMesh *mesh = ue_py_check_type<UStaticMesh>(self);
+    if (!mesh)
+        return PyErr_Format(PyExc_Exception, "uobject is not a UStaticMesh");
+
+    FBoxSphereBounds bounds = mesh->GetBounds();
+    UScriptStruct *u_struct = FindObject<UScriptStruct>(ANY_PACKAGE, UTF8_TO_TCHAR("BoxSphereBounds"));
+    if (!u_struct)
+    {
+        return PyErr_Format(PyExc_Exception, "unable to get BoxSphereBounds struct");
+    }
+    return py_ue_new_owned_uscriptstruct(u_struct, (uint8 *)&bounds);
+}
 
 #if WITH_EDITOR
 
-#include "Engine/StaticMesh.h"
 #include "Wrappers/UEPyFRawMesh.h"
 #include "Editor/UnrealEd/Private/GeomFitUtils.h"
 #include "FbxMeshUtils.h"

--- a/Source/UnrealEnginePython/Private/UObject/UEPyStaticMesh.h
+++ b/Source/UnrealEnginePython/Private/UObject/UEPyStaticMesh.h
@@ -4,6 +4,8 @@
 
 #include "UEPyModule.h"
 
+PyObject *py_ue_static_mesh_get_bounds(ue_PyUObject *self, PyObject * args);
+
 #if WITH_EDITOR
 PyObject *py_ue_static_mesh_build(ue_PyUObject *, PyObject *);
 PyObject *py_ue_static_mesh_create_body_setup(ue_PyUObject *, PyObject *);


### PR DESCRIPTION
This patch makes it so you can get the BoxSphereBounds from a UStaticMesh object:

```py
    from unreal_engine.classes import StaticMesh
    sm = unreal_engine.load_object(StaticMesh, '/Game/Meshes/...')
    b = sm.get_static_mesh_bounds()
    print(b.BoxExtent, b.SphereRadius)
```