### PR TITLE
Use C++ conformant “_fileno” instead of “fileno”.

### DIFF
--- a/Source/UnrealEnginePython/Private/UnrealEnginePython.cpp
+++ b/Source/UnrealEnginePython/Private/UnrealEnginePython.cpp
@@ -460,9 +460,9 @@ void FUnrealEnginePythonModule::StartupModule()
 	// Restore stdio state after Py_Initialize set it to O_BINARY, otherwise
 	// everything that the engine will output is going to be encoded in UTF-16.
 	// The behaviour is described here: https://bugs.python.org/issue16587
-	_setmode(fileno(stdin), O_TEXT);
-	_setmode(fileno(stdout), O_TEXT);
-	_setmode(fileno(stderr), O_TEXT);
+	_setmode(_fileno(stdin), O_TEXT);
+	_setmode(_fileno(stdout), O_TEXT);
+	_setmode(_fileno(stderr), O_TEXT);
 
 	// Also restore the user-requested UTF-8 flag if relevant (behaviour copied
 	// from LaunchEngineLoop.cpp).


### PR DESCRIPTION
Thanks for accepting the previous PR. I’m sorry I missed these compilation warnings, here’s a PR to fix them.

    [ WARNING ] 2>Engine\Plugins\UnrealEnginePython\Source\UnrealEnginePython\Private\UnrealEnginePython.cpp(455): warning C4996: 'fileno': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _fileno. See online help for details.
    [  NOTIF  ] 2>  C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\ucrt\stdio.h(2459): note: see declaration of 'fileno'
    [ WARNING ] 2>Engine\Plugins\UnrealEnginePython\Source\UnrealEnginePython\Private\UnrealEnginePython.cpp(456): warning C4996: 'fileno': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _fileno. See online help for details.
    [  NOTIF  ] 2>  C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\ucrt\stdio.h(2459): note: see declaration of 'fileno'
    [ WARNING ] 2>Engine\Plugins\UnrealEnginePython\Source\UnrealEnginePython\Private\UnrealEnginePython.cpp(457): warning C4996: 'fileno': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _fileno. See online help for details.
    [  NOTIF  ] 2>  C:\Program Files (x86)\Windows Kits\10\include\10.0.17763.0\ucrt\stdio.h(2459): note: see declaration of 'fileno'
