### PR TITLE
Add support for multiple out params

### DIFF
--- a/Source/UnrealEnginePython/Private/PythonFunction.cpp
+++ b/Source/UnrealEnginePython/Private/PythonFunction.cpp
@@ -54,8 +54,8 @@ void UPythonFunction::CallPythonCallable(FFrame& Stack, RESULT_DECL)
 
 	uint8 *frame = Stack.Locals;
 
-	// is it a blueprint call ?
-	if (*Stack.Code == EX_EndFunctionParms) {
+	if (*Stack.Code == EX_EndFunctionParms)
+    {   // native call
 		for (UProperty *prop = (UProperty *)function->Children; prop; prop = (UProperty *)prop->Next) {
 			if (prop->PropertyFlags & CPF_OutParm)
 				continue;
@@ -72,10 +72,8 @@ void UPythonFunction::CallPythonCallable(FFrame& Stack, RESULT_DECL)
 		}
 	}
 	else
-    {
-		//UE_LOG(LogPython, Warning, TEXT("BLUEPRINT CALL"));
-        // largely copied from ScriptCore.cpp::CallFunction
-        // for BP calls, we need to set up the FOutParmRec stuff ourselves
+    {   // blueprint call
+        // largely copied from ScriptCore.cpp::CallFunction - for BP calls, we need to set up the FOutParmRec stuff ourselves
         Stack.OutParms = NULL;
 		frame = (uint8 *)FMemory_Alloca(function->PropertiesSize);
 		FMemory::Memzero(frame, function->PropertiesSize);
@@ -118,7 +116,7 @@ void UPythonFunction::CallPythonCallable(FFrame& Stack, RESULT_DECL)
 		return;
 	}
 
-	// get return value and/or any out params - for convenience, if a single item is returned, wrap it in a tuple so that we can process
+    // get return value and/or any out params - for convenience, if a single item is returned, wrap it in a tuple so that we can process
     // multi-out params and single out params with one block of code
     bool wrapped_ret = false;
     if (!PyTuple_Check(ret))
@@ -143,14 +141,14 @@ void UPythonFunction::CallPythonCallable(FFrame& Stack, RESULT_DECL)
         UProperty *prop = *It;
         PyObject *py_obj = PyTuple_GetItem(ret, tuple_index);
         if (prop->PropertyFlags & CPF_ReturnParm)
-        {   // handle the return value specially by have it write directly to the stack
+        {   // handle the return value specially by having it write directly to the stack
             if (!ue_py_convert_pyobject(py_obj, prop, (uint8*)RESULT_PARAM - prop->GetOffset_ForUFunction(), 0))
             {
                 UE_LOG(LogPython, Error, TEXT("Invalid return value type for function %s"), *function->GetFName().ToString());
             }
         }
         else
-        {
+        {   // Find the given FOutParmRec for this property
             uint8 *out_frame = frame;
             for (FOutParmRec *rec = Stack.OutParms; rec != nullptr; rec = rec->NextOutParm)
             {

--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -2915,42 +2915,46 @@ PyObject *py_ue_ufunction_call(UFunction *u_function, UObject *u_obj, PyObject *
 
 	Py_ssize_t tuple_len = PyTuple_Size(args);
 
-	int has_out_params = 0;
+	int num_out_params = 0;
 
 	TFieldIterator<UProperty> PArgs(u_function);
-	for (; PArgs && ((PArgs->PropertyFlags & (CPF_Parm | CPF_ReturnParm)) == CPF_Parm); ++PArgs)
+	for (; PArgs && ((PArgs->PropertyFlags & CPF_Parm) == CPF_Parm); ++PArgs)
 	{
 		UProperty *prop = *PArgs;
-		if (argn < tuple_len)
-		{
-			PyObject *py_arg = PyTuple_GetItem(args, argn);
-			if (!py_arg)
-			{
-				py_ue_destroy_params(u_function, buffer);
-				return PyErr_Format(PyExc_TypeError, "unable to get pyobject for property %s", TCHAR_TO_UTF8(*prop->GetName()));
-			}
-			if (!ue_py_convert_pyobject(py_arg, prop, buffer, 0))
-			{
-				py_ue_destroy_params(u_function, buffer);
-				return PyErr_Format(PyExc_TypeError, "unable to convert pyobject to property %s (%s)", TCHAR_TO_UTF8(*prop->GetName()), TCHAR_TO_UTF8(*prop->GetClass()->GetName()));
-			}
-		}
-		else if (kwargs)
-		{
-			char *prop_name = TCHAR_TO_UTF8(*prop->GetName());
-			PyObject *dict_value = PyDict_GetItemString(kwargs, prop_name);
-			if (dict_value)
-			{
-				if (!ue_py_convert_pyobject(dict_value, prop, buffer, 0))
-				{
-					py_ue_destroy_params(u_function, buffer);
-					return PyErr_Format(PyExc_TypeError, "unable to convert pyobject to property %s (%s)", TCHAR_TO_UTF8(*prop->GetName()), TCHAR_TO_UTF8(*prop->GetClass()->GetName()));
-				}
-			}
-		}
-		if (prop->HasAnyPropertyFlags(CPF_OutParm) && (prop->IsA<UArrayProperty>() || prop->HasAnyPropertyFlags(CPF_ConstParm) == false))
-		{
-			has_out_params++;
+        if (prop->PropertyFlags & CPF_OutParm)
+        {
+            if (prop->IsA<UArrayProperty>() || prop->HasAnyPropertyFlags(CPF_ConstParm) == false)
+                num_out_params++;
+        }
+        else
+        {
+            if (argn < tuple_len)
+            {
+                PyObject *py_arg = PyTuple_GetItem(args, argn);
+                if (!py_arg)
+                {
+                    py_ue_destroy_params(u_function, buffer);
+                    return PyErr_Format(PyExc_TypeError, "unable to get pyobject for property %s", TCHAR_TO_UTF8(*prop->GetName()));
+                }
+                if (!ue_py_convert_pyobject(py_arg, prop, buffer, 0))
+                {
+                    py_ue_destroy_params(u_function, buffer);
+                    return PyErr_Format(PyExc_TypeError, "unable to convert pyobject to property %s (%s)", TCHAR_TO_UTF8(*prop->GetName()), TCHAR_TO_UTF8(*prop->GetClass()->GetName()));
+                }
+            }
+            else if (kwargs)
+            {
+                char *prop_name = TCHAR_TO_UTF8(*prop->GetName());
+                PyObject *dict_value = PyDict_GetItemString(kwargs, prop_name);
+                if (dict_value)
+                {
+                    if (!ue_py_convert_pyobject(dict_value, prop, buffer, 0))
+                    {
+                        py_ue_destroy_params(u_function, buffer);
+                        return PyErr_Format(PyExc_TypeError, "unable to convert pyobject to property %s (%s)", TCHAR_TO_UTF8(*prop->GetName()), TCHAR_TO_UTF8(*prop->GetClass()->GetName()));
+                    }
+                }
+            }
 		}
 		argn++;
 	}
@@ -2964,56 +2968,37 @@ PyObject *py_ue_ufunction_call(UFunction *u_function, UObject *u_obj, PyObject *
 
 	PyObject *ret = nullptr;
 
-	int has_ret_param = 0;
-	TFieldIterator<UProperty> Props(u_function);
-	for (; Props; ++Props)
+	if (num_out_params > 0)
 	{
-		UProperty *prop = *Props;
-		if (prop->GetPropertyFlags() & CPF_ReturnParm)
-		{
-			ret = ue_py_convert_property(prop, buffer, 0);
-			if (!ret)
-			{
-				// destroy params
-				py_ue_destroy_params(u_function, buffer);
-				return NULL;
-			}
-			has_ret_param = 1;
-			break;
-		}
-	}
+        // mirror Python function return behavior: 'return x' produces a single object, while 'return x,y' produces a tuple
+        if (num_out_params > 1)
+            ret = PyTuple_New(num_out_params);
 
-	if (has_out_params > 0)
-	{
-		PyObject *multi_ret = PyTuple_New(has_out_params + has_ret_param);
-		if (ret)
-		{
-			PyTuple_SetItem(multi_ret, 0, ret);
-		}
 		TFieldIterator<UProperty> OProps(u_function);
+        int cur_out_param = 0;
 		for (; OProps; ++OProps)
 		{
 			UProperty *prop = *OProps;
 			if (prop->HasAnyPropertyFlags(CPF_OutParm) && (prop->IsA<UArrayProperty>() || prop->HasAnyPropertyFlags(CPF_ConstParm) == false))
 			{
-				// skip return param as it must be always the first
-				if (prop->GetPropertyFlags() & CPF_ReturnParm)
-					continue;
 				PyObject *py_out = ue_py_convert_property(prop, buffer, 0);
 				if (!py_out)
 				{
-					Py_DECREF(multi_ret);
+                    if (ret)
+                        Py_DECREF(ret);
 					// destroy params
 					py_ue_destroy_params(u_function, buffer);
 					return NULL;
 				}
-				PyTuple_SetItem(multi_ret, has_ret_param, py_out);
-				has_ret_param++;
+                if (num_out_params > 1)
+                    PyTuple_SetItem(ret, cur_out_param++, py_out);
+                else
+                {   // there's just one return/output param and this is it
+                    ret = py_out;
+                    break;
+                }
 			}
 		}
-		// destroy params
-		py_ue_destroy_params(u_function, buffer);
-		return multi_ret;
 	}
 
 	// destroy params
@@ -3071,6 +3056,132 @@ PyObject *ue_bind_pyevent(ue_PyUObject *u_obj, FString event_name, PyObject *py_
 	Py_RETURN_NONE;
 }
 
+// Creates and configures a UProperty on the given owner using info from a PyObject (typically a type
+// object) representing function parameter or return value type info, or nullptr if the given type is unsupported.
+UProperty *new_property_from_pyobject(UObject *owner, const char *prop_name, PyObject *value)
+{
+    UProperty *prop = nullptr;
+    if (PyType_Check(value))
+    {
+        if ((PyTypeObject *)value == &PyFloat_Type)
+        {
+            prop = NewObject<UFloatProperty>(owner, UTF8_TO_TCHAR(prop_name), RF_Public);
+        }
+        else if ((PyTypeObject *)value == &PyUnicode_Type)
+        {
+            prop = NewObject<UStrProperty>(owner, UTF8_TO_TCHAR(prop_name), RF_Public);
+        }
+        else if ((PyTypeObject *)value == &PyBool_Type)
+        {
+            prop = NewObject<UBoolProperty>(owner, UTF8_TO_TCHAR(prop_name), RF_Public);
+        }
+        else if ((PyTypeObject *)value == &PyLong_Type)
+        {
+            prop = NewObject<UIntProperty>(owner, UTF8_TO_TCHAR(prop_name), RF_Public);
+        }
+        else if ((PyTypeObject *)value == &ue_PyFVectorType)
+        {
+            UStructProperty *prop_struct = NewObject<UStructProperty>(owner, UTF8_TO_TCHAR(prop_name), RF_Public);
+            prop_struct->Struct = TBaseStructure<FVector>::Get();
+            prop = prop_struct;
+        }
+        else if ((PyTypeObject *)value == &ue_PyFRotatorType)
+        {
+            UStructProperty *prop_struct = NewObject<UStructProperty>(owner, UTF8_TO_TCHAR(prop_name), RF_Public);
+            prop_struct->Struct = TBaseStructure<FRotator>::Get();
+            prop = prop_struct;
+        }
+        else if ((PyTypeObject *)value == &ue_PyFLinearColorType)
+        {
+            UStructProperty *prop_struct = NewObject<UStructProperty>(owner, UTF8_TO_TCHAR(prop_name), RF_Public);
+            prop_struct->Struct = TBaseStructure<FLinearColor>::Get();
+            prop = prop_struct;
+        }
+        else if ((PyTypeObject *)value == &ue_PyFColorType)
+        {
+            UStructProperty *prop_struct = NewObject<UStructProperty>(owner, UTF8_TO_TCHAR(prop_name), RF_Public);
+            prop_struct->Struct = TBaseStructure<FColor>::Get();
+            prop = prop_struct;
+        }
+        else if ((PyTypeObject *)value == &ue_PyFTransformType)
+        {
+            UStructProperty *prop_struct = NewObject<UStructProperty>(owner, UTF8_TO_TCHAR(prop_name), RF_Public);
+            prop_struct->Struct = TBaseStructure<FTransform>::Get();
+            prop = prop_struct;
+        }
+#if ENGINE_MINOR_VERSION > 18
+        else if ((PyTypeObject *)value == &ue_PyFQuatType)
+        {
+            UStructProperty *prop_struct = NewObject<UStructProperty>(owner, UTF8_TO_TCHAR(prop_name), RF_Public);
+            prop_struct->Struct = TBaseStructure<FQuat>::Get();
+            prop = prop_struct;
+        }
+#endif
+        else if (PyObject_IsInstance(value, (PyObject *)&PyType_Type))
+        {
+            // Method annotation like foo:typing.Type[Pawn] produces annotations like typing.Type[Pawn], with .__args__ = (Pawn,)
+            PyObject *type_args = PyObject_GetAttrString(value, "__args__");
+            if (!type_args)
+            {
+                UE_LOG(LogPython, Error, TEXT("missing type info on %s"), UTF8_TO_TCHAR(*owner->GetName()));
+                return nullptr;
+            }
+            if (PyTuple_Size(type_args) != 1)
+            {
+                Py_DECREF(type_args);
+                UE_LOG(LogPython, Error, TEXT("exactly one class is allowed in type info for %s"), UTF8_TO_TCHAR(*owner->GetName()));
+                return nullptr;
+            }
+            PyObject *py_class = PyTuple_GetItem(type_args, 0);
+            ue_PyUObject *py_obj = ue_is_pyuobject(py_class);
+            if (!py_obj)
+            {
+                Py_DECREF(type_args);
+                UE_LOG(LogPython, Error, TEXT("type for %s must be a ue_PyUObject"), UTF8_TO_TCHAR(*owner->GetName()));
+                return nullptr;
+            }
+            if (!py_obj->ue_object->IsA<UClass>())
+            {
+                Py_DECREF(type_args);
+                UE_LOG(LogPython, Error, TEXT("type for %s must be a UClass"), UTF8_TO_TCHAR(*owner->GetName()));
+                return nullptr;
+            }
+            UClassProperty *prop_class = NewObject<UClassProperty>(owner, UTF8_TO_TCHAR(prop_name), RF_Public);
+            prop_class->SetMetaClass((UClass*)py_obj->ue_object);
+            prop_class->PropertyClass = UClass::StaticClass();
+            prop = prop_class;
+            Py_DECREF(type_args);
+        }
+    }
+    else if (ue_PyUObject *py_obj = ue_is_pyuobject(value))
+    {
+        if (py_obj->ue_object->IsA<UClass>())
+        {
+            UClass *p_u_class = (UClass *)py_obj->ue_object;
+            UObjectProperty *prop_base = NewObject<UObjectProperty>(owner, UTF8_TO_TCHAR(prop_name), RF_Public);
+            prop_base->SetPropertyClass(p_u_class);
+            prop = prop_base;
+        }
+#if ENGINE_MINOR_VERSION > 17
+        else if (py_obj->ue_object->IsA<UEnum>())
+        {
+            UEnumProperty *prop_enum = NewObject<UEnumProperty>(owner, UTF8_TO_TCHAR(prop_name), RF_Public);
+            UNumericProperty *prop_underlying = NewObject<UByteProperty>(prop_enum, TEXT("UnderlyingType"), RF_Public);
+            prop_enum->SetEnum((UEnum*)py_obj->ue_object);
+            prop_enum->AddCppProperty(prop_underlying);
+            prop = prop_enum;
+        }
+#endif
+        else if (py_obj->ue_object->IsA<UStruct>())
+        {
+            UStructProperty *prop_struct = NewObject<UStructProperty>(owner, UTF8_TO_TCHAR(prop_name), RF_Public);
+            prop_struct->Struct = (UScriptStruct*)py_obj->ue_object;
+            prop = prop_struct;
+        }
+    }
+    return prop;
+}
+
 UFunction *unreal_engine_add_function(UClass *u_class, char *name, PyObject *py_callable, uint32 function_flags)
 {
 
@@ -3085,6 +3196,26 @@ UFunction *unreal_engine_add_function(UClass *u_class, char *name, PyObject *py_
 			return nullptr;
 		}
 	}
+
+    // note the index of the return param, if any
+    int return_param_index = -1;
+    if (parent_function)
+    {
+        TFieldIterator<UProperty> It(parent_function);
+        int cur_index = 0;
+        while (It)
+        {
+            UProperty *p = *It;
+            if (p->PropertyFlags & CPF_ReturnParm)
+            {
+                return_param_index = cur_index;
+                break;
+            }
+            if (p->PropertyFlags & CPF_OutParm)
+                cur_index++;
+            ++It;
+        }
+    }
 
 	UPythonFunction *function = NewObject<UPythonFunction>(u_class, UTF8_TO_TCHAR(name), RF_Public | RF_Transient | RF_MarkAsNative);
 	function->SetPyCallable(py_callable);
@@ -3147,126 +3278,7 @@ UFunction *unreal_engine_add_function(UClass *u_class, char *name, PyObject *py_
 		if (!value)
 			continue;
 
-		UProperty *prop = nullptr;
-		if (PyType_Check(value))
-		{
-			if ((PyTypeObject *)value == &PyFloat_Type)
-			{
-				prop = NewObject<UFloatProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-			}
-			else if ((PyTypeObject *)value == &PyUnicode_Type)
-			{
-				prop = NewObject<UStrProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-			}
-			else if ((PyTypeObject *)value == &PyBool_Type)
-			{
-				prop = NewObject<UBoolProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-			}
-			else if ((PyTypeObject *)value == &PyLong_Type)
-			{
-				prop = NewObject<UIntProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-			}
-			else if ((PyTypeObject *)value == &ue_PyFVectorType)
-			{
-				UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-				prop_struct->Struct = TBaseStructure<FVector>::Get();
-				prop = prop_struct;
-			}
-			else if ((PyTypeObject *)value == &ue_PyFRotatorType)
-			{
-				UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-				prop_struct->Struct = TBaseStructure<FRotator>::Get();
-				prop = prop_struct;
-			}
-			else if ((PyTypeObject *)value == &ue_PyFLinearColorType)
-			{
-				UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-				prop_struct->Struct = TBaseStructure<FLinearColor>::Get();
-				prop = prop_struct;
-			}
-			else if ((PyTypeObject *)value == &ue_PyFColorType)
-			{
-				UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-				prop_struct->Struct = TBaseStructure<FColor>::Get();
-				prop = prop_struct;
-			}
-			else if ((PyTypeObject *)value == &ue_PyFTransformType)
-			{
-				UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-				prop_struct->Struct = TBaseStructure<FTransform>::Get();
-				prop = prop_struct;
-			}
-#if ENGINE_MINOR_VERSION > 18
-			else if ((PyTypeObject *)value == &ue_PyFQuatType)
-			{
-				UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-				prop_struct->Struct = TBaseStructure<FQuat>::Get();
-				prop = prop_struct;
-			}
-#endif
-			else if (PyObject_IsInstance(value, (PyObject *)&PyType_Type))
-			{
-				// Method annotation like foo:typing.Type[Pawn] produces annotations like typing.Type[Pawn], with .__args__ = (Pawn,)
-				PyObject *type_args = PyObject_GetAttrString(value, "__args__");
-				if (!type_args)
-				{
-					UE_LOG(LogPython, Error, TEXT("missing type info on %s"), UTF8_TO_TCHAR(name));
-					return nullptr;
-				}
-				if (PyTuple_Size(type_args) != 1)
-				{
-					Py_DECREF(type_args);
-					UE_LOG(LogPython, Error, TEXT("exactly one class is allowed in type info for %s"), UTF8_TO_TCHAR(name));
-					return nullptr;
-				}
-				PyObject *py_class = PyTuple_GetItem(type_args, 0);
-				ue_PyUObject *py_obj = ue_is_pyuobject(py_class);
-				if (!py_obj)
-				{
-					Py_DECREF(type_args);
-					UE_LOG(LogPython, Error, TEXT("type for %s must be a ue_PyUObject"), UTF8_TO_TCHAR(name));
-					return nullptr;
-				}
-				if (!py_obj->ue_object->IsA<UClass>())
-				{
-					Py_DECREF(type_args);
-					UE_LOG(LogPython, Error, TEXT("type for %s must be a UClass"), UTF8_TO_TCHAR(name));
-					return nullptr;
-				}
-				UClassProperty *prop_class = NewObject<UClassProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-				prop_class->SetMetaClass((UClass*)py_obj->ue_object);
-				prop_class->PropertyClass = UClass::StaticClass();
-				prop = prop_class;
-				Py_DECREF(type_args);
-			}
-		}
-		else if (ue_PyUObject *py_obj = ue_is_pyuobject(value))
-		{
-			if (py_obj->ue_object->IsA<UClass>())
-			{
-				UClass *p_u_class = (UClass *)py_obj->ue_object;
-				UObjectProperty *prop_base = NewObject<UObjectProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-				prop_base->SetPropertyClass(p_u_class);
-				prop = prop_base;
-			}
-#if ENGINE_MINOR_VERSION > 17
-			else if (py_obj->ue_object->IsA<UEnum>())
-			{
-				UEnumProperty *prop_enum = NewObject<UEnumProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-				UNumericProperty *prop_underlying = NewObject<UByteProperty>(prop_enum, TEXT("UnderlyingType"), RF_Public);
-				prop_enum->SetEnum((UEnum*)py_obj->ue_object);
-				prop_enum->AddCppProperty(prop_underlying);
-				prop = prop_enum;
-			}
-#endif
-			else if (py_obj->ue_object->IsA<UStruct>())
-			{
-				UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-				prop_struct->Struct = (UScriptStruct*)py_obj->ue_object;
-				prop = prop_struct;
-			}
-		}
-
+		UProperty *prop = new_property_from_pyobject(function, p_name, value);
 		if (prop)
 		{
 			prop->SetPropertyFlags(CPF_Parm);
@@ -3288,140 +3300,54 @@ UFunction *unreal_engine_add_function(UClass *u_class, char *name, PyObject *py_
 		PyObject *py_return_value = PyDict_GetItemString(annotations, "return");
 		if (py_return_value)
 		{
-			UE_LOG(LogPython, Warning, TEXT("Return Value found"));
-			UProperty *prop = nullptr;
-			char *p_name = (char *) "ReturnValue";
-			if (PyType_Check(py_return_value))
-			{
-				if ((PyTypeObject *)py_return_value == &PyFloat_Type)
-				{
-					prop = NewObject<UFloatProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-				}
-				else if ((PyTypeObject *)py_return_value == &PyUnicode_Type)
-				{
-					prop = NewObject<UStrProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-				}
-				else if ((PyTypeObject *)py_return_value == &PyBool_Type)
-				{
-					prop = NewObject<UBoolProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-				}
-				else if ((PyTypeObject *)py_return_value == &PyLong_Type)
-				{
-					prop = NewObject<UIntProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-				}
-				else if ((PyTypeObject *)py_return_value == &ue_PyFVectorType)
-				{
-					UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-					prop_struct->Struct = TBaseStructure<FVector>::Get();
-					prop = prop_struct;
-				}
-				else if ((PyTypeObject *)py_return_value == &ue_PyFRotatorType)
-				{
-					UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-					prop_struct->Struct = TBaseStructure<FRotator>::Get();
-					prop = prop_struct;
-				}
-				else if ((PyTypeObject *)py_return_value == &ue_PyFLinearColorType)
-				{
-					UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-					prop_struct->Struct = TBaseStructure<FLinearColor>::Get();
-					prop = prop_struct;
-				}
-				else if ((PyTypeObject *)py_return_value == &ue_PyFColorType)
-				{
-					UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-					prop_struct->Struct = TBaseStructure<FColor>::Get();
-					prop = prop_struct;
-				}
-				else if ((PyTypeObject *)py_return_value == &ue_PyFTransformType)
-				{
-					UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-					prop_struct->Struct = TBaseStructure<FTransform>::Get();
-					prop = prop_struct;
-				}
-#if ENGINE_MINOR_VERSION > 18
-				else if ((PyTypeObject *)py_return_value == &ue_PyFQuatType)
-				{
-					UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-					prop_struct->Struct = TBaseStructure<FQuat>::Get();
-					prop = prop_struct;
-				}
-#endif
-				else if (PyObject_IsInstance(py_return_value, (PyObject *)&PyType_Type))
-				{
-					// Method annotation like foo:typing.Type[Pawn] produces annotations like typing.Type[Pawn], with .__args__ = (Pawn,)
-					PyObject *type_args = PyObject_GetAttrString(py_return_value, "__args__");
-					if (!type_args)
-					{
-						UE_LOG(LogPython, Error, TEXT("missing type info on %s"), UTF8_TO_TCHAR(name));
-						return nullptr;
-					}
-					if (PyTuple_Size(type_args) != 1)
-					{
-						Py_DECREF(type_args);
-						UE_LOG(LogPython, Error, TEXT("exactly one class is allowed in type info for %s"), UTF8_TO_TCHAR(name));
-						return nullptr;
-					}
-					PyObject *py_class = PyTuple_GetItem(type_args, 0);
-					ue_PyUObject *py_obj = ue_is_pyuobject(py_class);
-					if (!py_obj)
-					{
-						Py_DECREF(type_args);
-						UE_LOG(LogPython, Error, TEXT("type for %s must be a ue_PyUObject"), UTF8_TO_TCHAR(name));
-						return nullptr;
-					}
-					if (!py_obj->ue_object->IsA<UClass>())
-					{
-						Py_DECREF(type_args);
-						UE_LOG(LogPython, Error, TEXT("type for %s must be a UClass"), UTF8_TO_TCHAR(name));
-						return nullptr;
-					}
-					UClassProperty *prop_class = NewObject<UClassProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-					prop_class->SetMetaClass((UClass*)py_obj->ue_object);
-					prop_class->PropertyClass = UClass::StaticClass();
-					prop = prop_class;
-					Py_DECREF(type_args);
-				}
-			}
-			else if (ue_PyUObject *py_obj = ue_is_pyuobject(py_return_value))
-			{
-				if (py_obj->ue_object->IsA<UClass>())
-				{
-					UClass *p_u_class = (UClass *)py_obj->ue_object;
-					UObjectProperty *prop_base = NewObject<UObjectProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-					prop_base->SetPropertyClass(p_u_class);
-					prop = prop_base;
-				}
-#if ENGINE_MINOR_VERSION > 17
-				else if (py_obj->ue_object->IsA<UEnum>())
-				{
-					UEnumProperty *prop_enum = NewObject<UEnumProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-					UNumericProperty *prop_underlying = NewObject<UByteProperty>(prop_enum, TEXT("UnderlyingType"), RF_Public);
-					prop_enum->SetEnum((UEnum*)py_obj->ue_object);
-					prop_enum->AddCppProperty(prop_underlying);
-					prop = prop_enum;
-				}
-#endif
-				else if (py_obj->ue_object->IsA<UStruct>())
-				{
-					UStructProperty *prop_struct = NewObject<UStructProperty>(function, UTF8_TO_TCHAR(p_name), RF_Public);
-					prop_struct->Struct = (UScriptStruct*)py_obj->ue_object;
-					prop = prop_struct;
-				}
-			}
-
-			if (prop)
-			{
-				prop->SetPropertyFlags(CPF_Parm | CPF_OutParm | CPF_ReturnParm);
-				*next_property = prop;
-				next_property = &prop->Next;
-				*next_property_link = prop;
-				next_property_link = &prop->PropertyLinkNext;
-			}
-			else
-			{
-				UE_LOG(LogPython, Warning, TEXT("Unable to map return value to function %s"), UTF8_TO_TCHAR(name));
-			}
+            if (PyTuple_Check(py_return_value))
+            {   // some combination of a return value and output params
+                UE_LOG(LogPython, Warning, TEXT("Multiple return values found"));
+                for (auto i=0; i < PyTuple_Size(py_return_value); i++)
+                {
+                    PyObject *item = PyTuple_GetItem(py_return_value, i);
+                    FString out_param_name(_T("ReturnValue"));
+                    if (i != return_param_index)
+                        out_param_name = FString::Printf(_T("OutParam%d"), i);
+                    UProperty *prop = new_property_from_pyobject(function, TCHAR_TO_UTF8(*out_param_name), item);
+                    if (prop)
+                    {
+                        uint64 flags = CPF_Parm | CPF_OutParm;
+                        if (i == return_param_index)
+                            flags |= CPF_ReturnParm;
+                        prop->SetPropertyFlags(flags);
+                        *next_property = prop;
+                        next_property = &prop->Next;
+                        *next_property_link = prop;
+                        next_property_link = &prop->PropertyLinkNext;
+                    }
+                    else
+                    {
+                        UE_LOG(LogPython, Warning, TEXT("Unable to map return value %d to function %s"), i, UTF8_TO_TCHAR(name));
+                    }
+                }
+            }
+            else
+            {   // either a single output param or a single return value
+                UE_LOG(LogPython, Warning, TEXT("Return value or single output value found"));
+                FString param_name(return_param_index == -1 ? _T("OutParam0") : _T("ReturnValue"));
+                UProperty *prop = new_property_from_pyobject(function, TCHAR_TO_UTF8(*param_name), py_return_value);
+                if (prop)
+                {
+                    uint64 flags = CPF_Parm | CPF_OutParm;
+                    if (return_param_index != -1)
+                        flags |= CPF_ReturnParm;
+                    prop->SetPropertyFlags(flags);
+                    *next_property = prop;
+                    next_property = &prop->Next;
+                    *next_property_link = prop;
+                    next_property_link = &prop->PropertyLinkNext;
+                }
+                else
+                {
+                    UE_LOG(LogPython, Warning, TEXT("Unable to map return value to function %s"), UTF8_TO_TCHAR(name));
+                }
+            }
 		}
 	}
 
@@ -3440,7 +3366,7 @@ UFunction *unreal_engine_add_function(UClass *u_class, char *name, PyObject *py_
 				UProperty *p = *It;
 				if (p->PropertyFlags & CPF_Parm)
 				{
-					UE_LOG(LogPython, Warning, TEXT("Parent PROP: %s %d/%d %d %d %d %s %p"), *p->GetName(), (int)p->PropertyFlags, (int)UFunction::GetDefaultIgnoredSignatureCompatibilityFlags(), (int)(p->PropertyFlags & ~UFunction::GetDefaultIgnoredSignatureCompatibilityFlags()), p->GetSize(), p->GetOffset_ForGC(), *p->GetClass()->GetName(), p->GetClass());
+					UE_LOG(LogPython, Warning, TEXT("Parent PROP: %s %X/%X %d %d %d %s %p"), *p->GetName(), (int)p->PropertyFlags, (int)UFunction::GetDefaultIgnoredSignatureCompatibilityFlags(), (int)(p->PropertyFlags & ~UFunction::GetDefaultIgnoredSignatureCompatibilityFlags()), p->GetSize(), p->GetOffset_ForGC(), *p->GetClass()->GetName(), p->GetClass());
 					UClassProperty *ucp = Cast<UClassProperty>(p);
 					if (ucp)
 					{
@@ -3456,7 +3382,7 @@ UFunction *unreal_engine_add_function(UClass *u_class, char *name, PyObject *py_
 				UProperty *p = *It2;
 				if (p->PropertyFlags & CPF_Parm)
 				{
-					UE_LOG(LogPython, Warning, TEXT("Function PROP: %s %d/%d %d %d %d %s %p"), *p->GetName(), (int)p->PropertyFlags, (int)UFunction::GetDefaultIgnoredSignatureCompatibilityFlags(), (int)(p->PropertyFlags & ~UFunction::GetDefaultIgnoredSignatureCompatibilityFlags()), p->GetSize(), p->GetOffset_ForGC(), *p->GetClass()->GetName(), p->GetClass());
+					UE_LOG(LogPython, Warning, TEXT("Function PROP: %s %X/%X %d %d %d %s %p"), *p->GetName(), (int)p->PropertyFlags, (int)UFunction::GetDefaultIgnoredSignatureCompatibilityFlags(), (int)(p->PropertyFlags & ~UFunction::GetDefaultIgnoredSignatureCompatibilityFlags()), p->GetSize(), p->GetOffset_ForGC(), *p->GetClass()->GetName(), p->GetClass());
 					UClassProperty *ucp = Cast<UClassProperty>(p);
 					if (ucp)
 					{
@@ -3475,11 +3401,14 @@ UFunction *unreal_engine_add_function(UClass *u_class, char *name, PyObject *py_
 
 	// allocate properties storage (ignore super)
 	TFieldIterator<UProperty> props(function, EFieldIteratorFlags::ExcludeSuper);
+    bool has_out_params = false;
 	for (; props; ++props)
 	{
 		UProperty *p = *props;
 		if (p->HasAnyPropertyFlags(CPF_Parm))
 		{
+            if (p->HasAnyPropertyFlags(CPF_OutParm))
+                has_out_params = true;
 			function->NumParms++;
 			function->ParmsSize = p->GetOffset_ForUFunction() + p->GetSize();
 			if (p->HasAnyPropertyFlags(CPF_ReturnParm))
@@ -3488,6 +3417,8 @@ UFunction *unreal_engine_add_function(UClass *u_class, char *name, PyObject *py_
 			}
 		}
 	}
+    if (has_out_params)
+        function_flags |= FUNC_HasOutParms;
 
 	if (parent_function)
 	{

--- a/Source/UnrealEnginePython/Private/UEPyModule.cpp
+++ b/Source/UnrealEnginePython/Private/UEPyModule.cpp
@@ -3401,23 +3401,28 @@ UFunction *unreal_engine_add_function(UClass *u_class, char *name, PyObject *py_
 
 	// allocate properties storage (ignore super)
 	TFieldIterator<UProperty> props(function, EFieldIteratorFlags::ExcludeSuper);
-    bool has_out_params = false;
+    int num_out_params = 0;
+    int num_return_params = 0;
 	for (; props; ++props)
 	{
 		UProperty *p = *props;
 		if (p->HasAnyPropertyFlags(CPF_Parm))
 		{
             if (p->HasAnyPropertyFlags(CPF_OutParm))
-                has_out_params = true;
+                num_out_params++;
 			function->NumParms++;
 			function->ParmsSize = p->GetOffset_ForUFunction() + p->GetSize();
 			if (p->HasAnyPropertyFlags(CPF_ReturnParm))
 			{
 				function->ReturnValueOffset = p->GetOffset_ForUFunction();
+                num_return_params++;
 			}
 		}
 	}
-    if (has_out_params)
+
+    // UProps have both out + return flags set on the property that is the return value, but a function with a return value but no other
+    // out properties does not get HasOutParms set.
+    if (num_out_params > 0) //num_return_params)
         function_flags |= FUNC_HasOutParms;
 
 	if (parent_function)


### PR DESCRIPTION
See issue #621 - this patch makes it so that Python can properly call C++ or BP methods with one or more output parameters as well as C++ methods that have both output parameters and a return value. Further, it makes it so that in Python you can override and implement methods that have both return values and output parameters. A side effect of this patch is that so far it appears to have fixed #622.

Note that when combining out params and a return value, the return value needs to come last in the type annotation info, e.g. given a C++ base class method like this:
```c
    UFUNCTION(BlueprintCallable, BlueprintNativeEvent) float Func(int i, int& oi);
```

you'd implement it in Python like this:
```py
    def Func(self, i:int) -> (int, float):
        return 5, 12.34 # 5 is the out param, 12.34 is the return value
```

In terms of lines of code, the biggest change is moving property creation to ```new_property_from_pyobject``` since it is needed in more places (and was getting unwieldy anyway).

Given that this patch affects some pretty fundamental code, I also created a project that runs through a large set of test scenarios: https://github.com/dfb/uepy_test_prjs/tree/master/output_params
