### PR TITLE
Add backwards compatibility macro for TCHAR_TO_WCHAR.

### DIFF
--- a/Source/UnrealEnginePython/Private/UEPyModule.h
+++ b/Source/UnrealEnginePython/Private/UEPyModule.h
@@ -14,6 +14,15 @@
 #include "Wrappers/UEPyFColor.h"
 #include "Wrappers/UEPyFLinearColor.h"
 
+// backward compatibility for UE4.20 TCHAR_TO_WCHAR
+#ifndef TCHAR_TO_WCHAR
+	// SIZEOF_WCHAR_T is provided by pyconfig.h
+	#if SIZEOF_WCHAR_T == (PLATFORM_TCHAR_IS_4_BYTES ? 4 : 2)
+		#define TCHAR_TO_WCHAR(str) str
+	#else
+		#define TCHAR_TO_WCHAR(str) (wchar_t*)StringCast<wchar_t>(static_cast<const TCHAR*>(str)).Get()
+	#endif
+#endif
 
 
 UWorld *ue_get_uworld(ue_PyUObject *);


### PR DESCRIPTION
This macro was only introduced in UE4.20. We copy it if wchar_t and TCHAR differ in size.