### PR TITLE
Adds version checking before calling TCHAR_TO_WCHAR

### DIFF
--- a/Source/UnrealEnginePython/Private/PyCommandlet.cpp
+++ b/Source/UnrealEnginePython/Private/PyCommandlet.cpp
@@ -91,7 +91,11 @@ int32 UPyCommandlet::Main(const FString& CommandLine)
 #if PY_MAJOR_VERSION >= 3
 		argv[i] = (wchar_t*)malloc(PyArgv[i].Len() + 1);
 #if PLATFORM_MAC || PLATFORM_LINUX
+	#if ENGINE_MINOR_VERSION >= 20
 		wcsncpy(argv[i], (const wchar_t *) TCHAR_TO_WCHAR(*PyArgv[i].ReplaceEscapedCharWithChar()), PyArgv[i].Len() + 1);
+	#else
+		wcsncpy(argv[i], *PyArgv[i].ReplaceEscapedCharWithChar(), PyArgv[i].Len() + 1);
+	#endif
 #elif PLATFORM_ANDROID
 		wcsncpy(argv[i], (const wchar_t *)*PyArgv[i].ReplaceEscapedCharWithChar(), PyArgv[i].Len() + 1);
 #else

--- a/Source/UnrealEnginePython/Private/UnrealEnginePython.cpp
+++ b/Source/UnrealEnginePython/Private/UnrealEnginePython.cpp
@@ -121,7 +121,11 @@ void FUnrealEnginePythonModule::UESetupPythonInterpreter(bool verbose)
 	for (int32 i = 0; i < Args.Num(); i++)
 	{
 #if PY_MAJOR_VERSION >= 3
+	#if ENGINE_MINOR_VERSION >= 20
 		argv[i] = (wchar_t *)(TCHAR_TO_WCHAR(*Args[i]));
+	#else
+		argv[i] = (wchar_t *)(*Args[i]);
+	#endif
 #else
 		argv[i] = TCHAR_TO_UTF8(*Args[i]);
 #endif


### PR DESCRIPTION
This is a fix for issue #602 that includes a version check so that pre 4.20 projects aren't affected.

If this check is not necessary with @samhocevar pull request #627 please let me know and I will delete this.