### PR TITLE
look for python in alternate custom location

### DIFF
--- a/Source/UnrealEnginePython/UnrealEnginePython.Build.cs
+++ b/Source/UnrealEnginePython/UnrealEnginePython.Build.cs
@@ -292,6 +292,11 @@ public class UnrealEnginePython : ModuleRules
         if (!string.IsNullOrEmpty(environmentPath))
             paths.Insert(0, environmentPath);
 
+        // look in an alternate custom location
+        environmentPath = System.Environment.GetEnvironmentVariable("UNREALENGINEPYTHONHOME");
+        if (!string.IsNullOrEmpty(environmentPath))
+            paths.Insert(0, environmentPath);
+
         foreach (string path in paths)
         {
             string actualPath = path;


### PR DESCRIPTION
A minor quality-of-life patch for your consideration: have build.cs check an env var specific to UnrealEnginePython for where to locate the Python to use.

Background: we use different versions of Python for different things, and on Windows for various reasons we end up having to put them in non-standard locations, and unfortunately also sometimes have to have multiple versions of Python installed on a single machine. So every time we clone UEP we have to go in and customize where it looks, but if we could just set an env var then we wouldn't need to change UEP to do that. But we can't change e.g. PYTHONHOME because we can't mess up anything else that uses Python, and we want to make sure that we all use the exact same version of Python with UEP.

I have zero preference for what the env var is named but hope you'll consider allowing something like this. Thanks!