### PR TITLE
Add support for unbind_event

### DIFF
--- a/Source/UnrealEnginePython/Private/PythonDelegate.cpp
+++ b/Source/UnrealEnginePython/Private/PythonDelegate.cpp
@@ -1,6 +1,7 @@
 
 #include "PythonDelegate.h"
 #include "UEPyModule.h"
+#include "UEPyCallable.h"
 
 UPythonDelegate::UPythonDelegate()
 {
@@ -101,6 +102,12 @@ void UPythonDelegate::PyInputAxisHandler(float value)
 	Py_DECREF(ret);
 }
 
+bool UPythonDelegate::UsesPyCallable(PyObject *other)
+{
+    ue_PyCallable *other_callable = (ue_PyCallable*)other;
+    ue_PyCallable *this_callable = (ue_PyCallable*)py_callable;
+    return other_callable->u_function == this_callable->u_function && other_callable->u_target == this_callable->u_target;
+}
 
 UPythonDelegate::~UPythonDelegate()
 {

--- a/Source/UnrealEnginePython/Private/UEPyModule.h
+++ b/Source/UnrealEnginePython/Private/UEPyModule.h
@@ -35,6 +35,7 @@ void ue_bind_events_for_py_class_by_attribute(UObject *, PyObject *);
 
 void ue_autobind_events_for_pyclass(ue_PyUObject *, PyObject *);
 PyObject *ue_bind_pyevent(ue_PyUObject *, FString, PyObject *, bool);
+PyObject *ue_unbind_pyevent(ue_PyUObject *, FString, PyObject *, bool);
 
 PyObject *py_ue_ufunction_call(UFunction *, UObject *, PyObject *, int, PyObject *);
 

--- a/Source/UnrealEnginePython/Private/UObject/UEPyObject.cpp
+++ b/Source/UnrealEnginePython/Private/UObject/UEPyObject.cpp
@@ -1517,6 +1517,25 @@ PyObject *py_ue_bind_event(ue_PyUObject * self, PyObject * args)
 	return ue_bind_pyevent(self, FString(event_name), py_callable, true);
 }
 
+PyObject *py_ue_unbind_event(ue_PyUObject * self, PyObject * args)
+{
+	ue_py_check(self);
+
+	char *event_name;
+	PyObject *py_callable;
+	if (!PyArg_ParseTuple(args, "sO:bind_event", &event_name, &py_callable))
+	{
+		return NULL;
+	}
+
+	if (!PyCallable_Check(py_callable))
+	{
+		return PyErr_Format(PyExc_Exception, "object is not callable");
+	}
+
+	return ue_unbind_pyevent(self, FString(event_name), py_callable, true);
+}
+
 PyObject *py_ue_delegate_bind_ufunction(ue_PyUObject * self, PyObject * args)
 {
 	ue_py_check(self);

--- a/Source/UnrealEnginePython/Private/UObject/UEPyObject.h
+++ b/Source/UnrealEnginePython/Private/UObject/UEPyObject.h
@@ -51,6 +51,7 @@ PyObject *py_ue_enum_user_defined_names(ue_PyUObject *, PyObject *);
 
 
 PyObject *py_ue_bind_event(ue_PyUObject *, PyObject *);
+PyObject *py_ue_unbind_event(ue_PyUObject *, PyObject *);
 PyObject *py_ue_add_function(ue_PyUObject *, PyObject *);
 PyObject *py_ue_add_property(ue_PyUObject *, PyObject *);
 

--- a/Source/UnrealEnginePython/Public/PythonDelegate.h
+++ b/Source/UnrealEnginePython/Public/PythonDelegate.h
@@ -13,6 +13,7 @@ public:
 	~UPythonDelegate();
 	virtual void ProcessEvent(UFunction *function, void *Parms) override;
 	void SetPyCallable(PyObject *callable);
+    bool UsesPyCallable(PyObject *callable);
 	void SetSignature(UFunction *original_signature);
 
 	void PyInputHandler();

--- a/Source/UnrealEnginePython/Public/PythonHouseKeeper.h
+++ b/Source/UnrealEnginePython/Public/PythonHouseKeeper.h
@@ -238,6 +238,17 @@ public:
 		return Garbaged;
 		}
 
+    UPythonDelegate *FindDelegate(UObject *Owner, PyObject *PyCallable)
+    {
+		for (int32 i = PyDelegatesTracker.Num() - 1; i >= 0; --i)
+		{
+			FPythonDelegateTracker &Tracker = PyDelegatesTracker[i];
+            if (Tracker.Owner.Get() == Owner && Tracker.Delegate->UsesPyCallable(PyCallable))
+                return Tracker.Delegate;
+        }
+        return nullptr;
+    }
+
 	UPythonDelegate *NewDelegate(UObject *Owner, PyObject *PyCallable, UFunction *Signature)
 	{
 		UPythonDelegate *Delegate = NewObject<UPythonDelegate>();


### PR DESCRIPTION
Currently you can bind a Python callable to an event dispatcher:

```py
someEventEmitter.bind_event('SomeEvent', self.OnSomeEvent)
```

But I couldn't find any way to later unbind that. This patch adds support for:

```py
someEventEmitter.unbind_event('SomeEvent', self.OnSomeEvent)
```
