### PR TITLE
Fix include path when compiling as engine plugin.

### DIFF
--- a/Source/PythonAutomation/Public/PythonAutomationModule.h
+++ b/Source/PythonAutomation/Public/PythonAutomationModule.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "ModuleInterface.h"
+#include "Modules/ModuleInterface.h"
 
 class FPythonAutomationModule : public IModuleInterface
 {

--- a/UnrealEnginePython.uplugin
+++ b/UnrealEnginePython.uplugin
@@ -10,7 +10,7 @@
 	"DocsURL": "",
 	"MarketplaceURL": "",
 	"SupportURL": "",
-	"EnabledByDefault": true,
+	"EnabledByDefault": false,
 	"CanContainContent": true,
 	"IsBetaVersion": true,
 	"Installed": false,


### PR DESCRIPTION
The proper include path for the ModuleInterface.h header includes its Modules folder as seen in other source files for 4.22.