### PR TITLE
Fix number * FVector

### DIFF
--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFVector.cpp
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFVector.cpp
@@ -229,8 +229,17 @@ static PyObject *ue_py_fvector_sub(ue_PyFVector *self, PyObject *value)
 	return py_ue_new_fvector(vec);
 }
 
-static PyObject *ue_py_fvector_mul(ue_PyFVector *self, PyObject *value)
+static PyObject *ue_py_fvector_mul(PyObject *a0, PyObject *a1)
 {
+    // At least one of the parameters is a ue_PyFVector, but we don't know which
+    ue_PyFVector *self = (ue_PyFVector*)a0;
+    PyObject *value = a1;
+    if (!py_ue_is_fvector(a0))
+    {
+        self = (ue_PyFVector*)a1;
+        value = a0;
+    }
+
 	FVector vec = self->vec;
 	ue_PyFVector *py_vec = py_ue_is_fvector(value);
 	if (py_vec)

--- a/Source/UnrealEnginePython/Private/Wrappers/UEPyFVector2D.cpp
+++ b/Source/UnrealEnginePython/Private/Wrappers/UEPyFVector2D.cpp
@@ -176,8 +176,17 @@ static PyObject *ue_py_fvector2d_sub(ue_PyFVector2D *self, PyObject *value)
 	return py_ue_new_fvector2d(vec);
 }
 
-static PyObject *ue_py_fvector2d_mul(ue_PyFVector2D *self, PyObject *value)
+static PyObject *ue_py_fvector2d_mul(PyObject *a0, PyObject *a1)
 {
+    // At least one of the parameters is a ue_PyFVector2D, but we don't know which
+    ue_PyFVector2D *self = (ue_PyFVector2D*)a0;
+    PyObject *value = a1;
+    if (!py_ue_is_fvector2d(a0))
+    {
+        self = (ue_PyFVector2D*)a1;
+        value = a0;
+    }
+
 	FVector2D vec = self->vec;
 	ue_PyFVector2D *py_vec = py_ue_is_fvector2d(value);
 	if (py_vec)


### PR DESCRIPTION
If you have an FVector and multiply it by a number, you get the expected results (a new vector scaled by the given number). But if you reverse the order of the arguments (and do number * FVector), the returned vector is garbage.

I verified that `ue_py_fvector_mul` in UEPyFVector.cpp is being called in both scenarios, but the problem is that that function assumes that the 'self' parameter will always be the FVector object, which is not the case, unfortunately. The [Python docs](https://docs.python.org/3/c-api/typeobj.html#number-structs) say:

> Note Binary and ternary functions must check the type of all their operands, and implement the necessary conversions (at least one of the operands is an instance of the defined type). If the operation is not defined for the given operands, binary and ternary functions must return Py_NotImplemented, if another error occurred they must return NULL and set an exception.

This patch changes the multiplication function to handle either case, and does the same for FVector2D. It's likely that other wrapper objects that implement the Python number protocol will have to change too.